### PR TITLE
issue-46: Fix equals comparision of Number objects to use equals().

### DIFF
--- a/src/main/java/com/mitchellbosecke/pebble/utils/OperatorUtils.java
+++ b/src/main/java/com/mitchellbosecke/pebble/utils/OperatorUtils.java
@@ -128,7 +128,8 @@ public class OperatorUtils {
         case LESS_THAN_EQUALS:
             return op1 <= op2;
         case EQUALS:
-            return op1 == op2;
+    		// == shouldn't be used here since two objects are being compared.
+        	return op1.equals(op2);
         default:
             return null;
         }
@@ -155,7 +156,8 @@ public class OperatorUtils {
         case LESS_THAN_EQUALS:
             return op1 <= op2;
         case EQUALS:
-            return op1 == op2;
+        	// == shouldn't be used here since two objects are being compared.
+            return op1.equals(op2);
         default:
             return null;
         }
@@ -182,7 +184,8 @@ public class OperatorUtils {
         case LESS_THAN_EQUALS:
             return op1 <= op2;
         case EQUALS:
-            return op1 == op2;
+        	// == shouldn't be used here since two objects are being compared.
+            return op1.equals(op2);
         default:
             return null;
         }
@@ -209,7 +212,8 @@ public class OperatorUtils {
         case LESS_THAN_EQUALS:
             return op1 <= op2;
         case EQUALS:
-            return op1 == op2;
+        	// == shouldn't be used here since two objects are being compared.
+            return op1.equals(op2);
         default:
             return null;
         }


### PR DESCRIPTION
Issue #46 was occurring since equals comparision of Number objects was done using == which doesn't work in all cases, especially with Float and Double. See http://stackoverflow.com/questions/12226757/

Fixed this by using equals() for eqaulity comaprision of Number objects. Also added a regression test in CoreOperatorsTest.java.

See: https://github.com/mbosecke/pebble/issues/46