### PR TITLE
Array&map support

### DIFF
--- a/src/main/java/com/mitchellbosecke/pebble/extension/core/CoreExtension.java
+++ b/src/main/java/com/mitchellbosecke/pebble/extension/core/CoreExtension.java
@@ -139,6 +139,7 @@ public class CoreExtension extends AbstractExtension {
         tests.put("empty", new EmptyTest());
         tests.put("even", new EvenTest());
         tests.put("iterable", new IterableTest());
+        tests.put("map", new MapTest());
         tests.put("null", new NullTest());
         tests.put("odd", new OddTest());
         return tests;

--- a/src/main/java/com/mitchellbosecke/pebble/extension/core/CoreExtension.java
+++ b/src/main/java/com/mitchellbosecke/pebble/extension/core/CoreExtension.java
@@ -20,6 +20,7 @@ import com.mitchellbosecke.pebble.extension.NodeVisitor;
 import com.mitchellbosecke.pebble.extension.Test;
 import com.mitchellbosecke.pebble.node.expression.AddExpression;
 import com.mitchellbosecke.pebble.node.expression.AndExpression;
+import com.mitchellbosecke.pebble.node.expression.ContainsExpression;
 import com.mitchellbosecke.pebble.node.expression.DivideExpression;
 import com.mitchellbosecke.pebble.node.expression.EqualsExpression;
 import com.mitchellbosecke.pebble.node.expression.FilterExpression;
@@ -92,6 +93,7 @@ public class CoreExtension extends AbstractExtension {
         operators.add(new BinaryOperatorImpl("and", 15, AndExpression.class, Associativity.LEFT));
         operators.add(new BinaryOperatorImpl("is", 20, PositiveTestExpression.class, Associativity.LEFT));
         operators.add(new BinaryOperatorImpl("is not", 20, NegativeTestExpression.class, Associativity.LEFT));
+        operators.add(new BinaryOperatorImpl("contains", 20, ContainsExpression.class, Associativity.LEFT));
         operators.add(new BinaryOperatorImpl("==", 30, EqualsExpression.class, Associativity.LEFT));
         operators.add(new BinaryOperatorImpl("equals", 30, EqualsExpression.class, Associativity.LEFT));
         operators.add(new BinaryOperatorImpl("!=", 30, NotEqualsExpression.class, Associativity.LEFT));
@@ -122,6 +124,7 @@ public class CoreExtension extends AbstractExtension {
         filters.put("last", new LastFilter());
         filters.put("lower", new LowerFilter());
         filters.put("numberformat", new NumberFormatFilter());
+        filters.put("slice", new SliceFilter());
         filters.put("sort", new SortFilter());
         filters.put("title", new TitleFilter());
         filters.put("trim", new TrimFilter());

--- a/src/main/java/com/mitchellbosecke/pebble/extension/core/MapTest.java
+++ b/src/main/java/com/mitchellbosecke/pebble/extension/core/MapTest.java
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * This file is part of Pebble.
+ * 
+ * Copyright (c) 2014 by Mitchell Bösecke
+ * 
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ ******************************************************************************/
+package com.mitchellbosecke.pebble.extension.core;
+
+import java.util.List;
+import java.util.Map;
+
+import com.mitchellbosecke.pebble.extension.Test;
+
+public class MapTest implements Test {
+
+    @Override
+    public List<String> getArgumentNames() {
+        return null;
+    }
+
+    @Override
+    public boolean apply(Object input, Map<String, Object> args) {
+        return input instanceof Map;
+    }
+
+}

--- a/src/main/java/com/mitchellbosecke/pebble/extension/core/SliceFilter.java
+++ b/src/main/java/com/mitchellbosecke/pebble/extension/core/SliceFilter.java
@@ -1,0 +1,64 @@
+/*******************************************************************************
+ * This file is part of Pebble.
+ * 
+ * Copyright (c) 2014 by Mitchell Bösecke
+ * 
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ ******************************************************************************/
+package com.mitchellbosecke.pebble.extension.core;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import com.mitchellbosecke.pebble.extension.Filter;
+
+public class SliceFilter implements Filter {
+
+    private final List<String> argumentNames = new ArrayList<>();
+
+    public SliceFilter() {
+        argumentNames.add("fromIndex");
+        argumentNames.add("toIndex");
+    }
+
+    @Override
+    public List<String> getArgumentNames() {
+        return argumentNames;
+    }
+
+    @Override
+    public Object apply(Object input, Map<String, Object> args) {
+        if (input == null) return null;
+        // argument parsing
+        Object argFrom = args.get("fromIndex");
+        if (!(argFrom instanceof Long)) 
+        	throw new IllegalArgumentException("Argument fromIndex must be a number. Actual type: " + (argFrom == null ? "null" : argFrom.getClass().getName()));
+        Object argTo = args.get("toIndex");
+        if (!(argTo instanceof Long)) 
+        	throw new IllegalArgumentException("Argument toIndex must be a number. Actual type: " + (argTo == null ? "null" : argTo.getClass().getName()));
+        int from = ((Long) argFrom).intValue();
+        int to = ((Long) argTo).intValue();
+        if (from < 0) throw new IllegalArgumentException("fromIndex must be greater than 0");
+        if (from >= to) throw new IllegalArgumentException("toIndex must be greater than fromIndex");
+        // slice input
+        if (input instanceof List) {
+        	List<?> value = (List<?>) input;
+            int length = value.size();
+            if (to > length) throw new IllegalArgumentException("toIndex must be smaller than input size: " + length);
+            //FIXME maybe sublist() is not the best option due to its implementation?
+        	return value.subList(from, to);
+        } else if (input.getClass().isArray()) {
+        	throw new UnsupportedOperationException("Pending implementation");
+        } else if (input instanceof String) {
+            String value = (String) input;
+            int length = value.length();
+            if (to > length) throw new IllegalArgumentException("toIndex must be smaller than input size: " + length);
+            return value.substring(from, to);
+        } else {
+        	throw new IllegalArgumentException("Slice filter can only be applied to String, List and array inputs. Actual type was: " + input.getClass().getName());
+        }
+    }
+
+}

--- a/src/main/java/com/mitchellbosecke/pebble/extension/core/SliceFilter.java
+++ b/src/main/java/com/mitchellbosecke/pebble/extension/core/SliceFilter.java
@@ -50,6 +50,7 @@ public class SliceFilter implements Filter {
             //FIXME maybe sublist() is not the best option due to its implementation?
         	return value.subList(from, to);
         } else if (input.getClass().isArray()) {
+        	//TODO support for arrays
         	throw new UnsupportedOperationException("Pending implementation");
         } else if (input instanceof String) {
             String value = (String) input;

--- a/src/main/java/com/mitchellbosecke/pebble/node/ForNode.java
+++ b/src/main/java/com/mitchellbosecke/pebble/node/ForNode.java
@@ -129,7 +129,7 @@ public class ForNode extends AbstractRenderableNode {
         return elseBody;
     }
 
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({ "unchecked", "rawtypes" })
     private Iterable<Object> toIterable(final Object obj) {
 
         Iterable<Object> result = null;
@@ -137,6 +137,11 @@ public class ForNode extends AbstractRenderableNode {
         if (obj instanceof Iterable<?>) {
 
             result = (Iterable<Object>) obj;
+
+        } else if (obj instanceof Map) {
+        	
+        	// raw type
+            result = ((Map)obj).entrySet();
 
         } else if (obj.getClass().isArray()) {
 
@@ -182,8 +187,9 @@ public class ForNode extends AbstractRenderableNode {
         }
         if (iterable instanceof Collection) {
             return ((Collection<?>) iterable).size();
-        }
-        if (iterable.getClass().isArray()) {
+        } else if (iterable instanceof Map) {
+        	return ((Map<?,?>) iterable).size();
+        } else if (iterable.getClass().isArray()) {
             return Array.getLength(iterable);
         }
 

--- a/src/main/java/com/mitchellbosecke/pebble/node/expression/ArrayExpression.java
+++ b/src/main/java/com/mitchellbosecke/pebble/node/expression/ArrayExpression.java
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * This file is part of Pebble.
+ * 
+ * Copyright (c) 2014 by Mitchell Bösecke
+ * 
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ ******************************************************************************/
+package com.mitchellbosecke.pebble.node.expression;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import com.mitchellbosecke.pebble.error.PebbleException;
+import com.mitchellbosecke.pebble.extension.NodeVisitor;
+import com.mitchellbosecke.pebble.template.EvaluationContext;
+import com.mitchellbosecke.pebble.template.PebbleTemplateImpl;
+
+public class ArrayExpression implements Expression<List<?>> {
+
+    private final List<Expression<?>> values;
+
+    public ArrayExpression() {
+    	this.values = Collections.emptyList();
+    }
+
+    public ArrayExpression(List<Expression<?>> values) {
+    	if (values == null) this.values = Collections.emptyList();
+    	else this.values = values;
+    }
+
+    @Override
+    public void accept(NodeVisitor visitor) {
+        visitor.visit(this);
+    }
+
+    @Override
+    public List<?> evaluate(PebbleTemplateImpl self, EvaluationContext context) throws PebbleException {
+    	List<Object> returnValues = new ArrayList<>(values.size());
+    	for (int i = 0; i < values.size(); i++) {
+    		Expression<?> expr = values.get(i);
+    		Object value = expr == null ? null : expr.evaluate(self, context);
+    		returnValues.add(value);
+    	}
+        return returnValues;
+    }
+
+}

--- a/src/main/java/com/mitchellbosecke/pebble/node/expression/ContainsExpression.java
+++ b/src/main/java/com/mitchellbosecke/pebble/node/expression/ContainsExpression.java
@@ -33,12 +33,95 @@ public class ContainsExpression extends BinaryExpression<Boolean> {
     	} else if (leftValue instanceof Map) {
     		return Boolean.valueOf(((Map)leftValue).containsKey(rightValue));
     	} else if (leftValue.getClass().isArray()) {
-    		//TODO support for arrays
-    		//Arrays.
-    		throw new UnsupportedOperationException("Contains operator does not yet implement arrays");
+    		return arrayContains(leftValue, rightValue);
     	} else {
     		throw new IllegalArgumentException("Contains operator can only be used on Collections, Maps and arrays. Actual type was: " + leftValue.getClass().getName());
     	}
+    }
+
+    //FIXME is this right? does it make sense to support?
+    private static boolean arrayContains(Object input, Object value) {
+    	if (input instanceof Object[]) {
+    		return containsObject((Object[])input, value);
+    	} else if (input instanceof boolean[]) {
+    		return containsBoolean((boolean[])input, value);
+    	} else if (input instanceof byte[]) {
+    		return containsByte((byte[])input, value);
+    	} else if (input instanceof char[]) {
+    		return containsChar((char[])input, value);
+    	} else if (input instanceof double[]) {
+    		return containsDouble((double[])input, value);
+    	} else if (input instanceof float[]) {
+    		return containsFloat((float[])input, value);
+    	} else if (input instanceof int[]) {
+    		return containsInt((int[])input, value);
+    	} else if (input instanceof long[]) {
+    		return containsLong((long[])input, value);
+    	} else {
+    		return containsShort((short[])input, value);
+    	}
+    }
+    private static boolean containsObject(Object[] array, Object value) {
+    	for (Object o : array) {
+    		if (value == o || (value != null && value.equals(o))) return true;
+    	}
+    	return false;
+    }
+    private static boolean containsBoolean(boolean[] array, Object value) {
+    	if (!(value instanceof Boolean)) return false;
+    	for (boolean b : array) {
+    		if (b == ((Boolean)value).booleanValue()) return true;
+    	}
+    	return false;
+    }
+    private static boolean containsByte(byte[] array, Object value) {
+    	if (!(value instanceof Byte)) return false;
+    	for (byte b : array) {
+    		if (b == ((Byte)value).byteValue()) return true;
+    	}
+    	return false;
+    }
+    private static boolean containsChar(char[] array, Object value) {
+    	if (!(value instanceof Character)) return false;
+    	for (char c : array) {
+    		if (c == ((Character)value).charValue()) return true;
+    	}
+    	return false;
+    }
+    private static boolean containsDouble(double[] array, Object value) {
+    	if (!(value instanceof Double)) return false;
+    	for (double d : array) {
+    		if (d == ((Double)value).doubleValue()) return true;
+    	}
+    	return false;
+    }
+    private static boolean containsFloat(float[] array, Object value) {
+    	if (!(value instanceof Float)) return false;
+    	for (float f : array) {
+    		if (f == ((Float)value).floatValue()) return true;
+    	}
+    	return false;
+    }
+    private static boolean containsInt(int[] array, Object value) {
+    	if (!(value instanceof Integer)) return false;
+    	for (int i : array) {
+    		if (i == ((Integer)value).intValue()) return true;
+    	}
+    	return false;
+    }
+    private static boolean containsLong(long[] array, Object value) {
+    	if (!(value instanceof Long)) return false;
+    	for (long l : array) {
+    		if (l == ((Long)value).longValue()) return true;
+    	}
+    	return false;
+    }
+    private static boolean containsShort(short[] array, Object value) {
+    	if (!(value instanceof Short)) return false;
+    	for (short s : array) {
+    		if (s == ((Short)value).shortValue()) return true;
+    	}
+    	return false;
     }
 
 }

--- a/src/main/java/com/mitchellbosecke/pebble/node/expression/ContainsExpression.java
+++ b/src/main/java/com/mitchellbosecke/pebble/node/expression/ContainsExpression.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * This file is part of Pebble.
+ * 
+ * Copyright (c) 2014 by Mitchell Bösecke
+ * 
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ ******************************************************************************/
+package com.mitchellbosecke.pebble.node.expression;
+
+import java.util.Collection;
+import java.util.Map;
+
+import com.mitchellbosecke.pebble.error.PebbleException;
+import com.mitchellbosecke.pebble.template.EvaluationContext;
+import com.mitchellbosecke.pebble.template.PebbleTemplateImpl;
+
+public class ContainsExpression extends BinaryExpression<Boolean> {
+
+    @SuppressWarnings({"rawtypes","unchecked"})
+	@Override
+    public Boolean evaluate(PebbleTemplateImpl self, EvaluationContext context) throws PebbleException {
+    	Object leftValue = getLeftExpression().evaluate(self, context);
+    	if (leftValue == null) return Boolean.FALSE;
+    	Object rightValue = getRightExpression().evaluate(self, context);
+
+    	if (leftValue instanceof Collection) {
+    		if (rightValue instanceof Collection) {
+    			return Boolean.valueOf(((Collection)leftValue).containsAll((Collection)rightValue));
+    		} else {
+    			return Boolean.valueOf(((Collection)leftValue).contains(rightValue));
+    		}
+    	} else if (leftValue instanceof Map) {
+    		return Boolean.valueOf(((Map)leftValue).containsKey(rightValue));
+    	} else if (leftValue.getClass().isArray()) {
+    		//TODO support for arrays
+    		//Arrays.
+    		throw new UnsupportedOperationException("Contains operator does not yet implement arrays");
+    	} else {
+    		throw new IllegalArgumentException("Contains operator can only be used on Collections, Maps and arrays. Actual type was: " + leftValue.getClass().getName());
+    	}
+    }
+
+}

--- a/src/main/java/com/mitchellbosecke/pebble/node/expression/MapExpression.java
+++ b/src/main/java/com/mitchellbosecke/pebble/node/expression/MapExpression.java
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * This file is part of Pebble.
+ * 
+ * Copyright (c) 2014 by Mitchell Bösecke
+ * 
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ ******************************************************************************/
+package com.mitchellbosecke.pebble.node.expression;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import com.mitchellbosecke.pebble.error.PebbleException;
+import com.mitchellbosecke.pebble.extension.NodeVisitor;
+import com.mitchellbosecke.pebble.template.EvaluationContext;
+import com.mitchellbosecke.pebble.template.PebbleTemplateImpl;
+
+public class MapExpression implements Expression<Map<?,?>> {
+
+	//FIXME should keys be of any type?
+    private final Map<Expression<?>,Expression<?>> entries;
+
+    public MapExpression() {
+    	this.entries = Collections.emptyMap();
+    }
+
+    public MapExpression(Map<Expression<?>,Expression<?>> entries) {
+    	if (entries == null) this.entries = Collections.emptyMap();
+    	else this.entries = entries;
+    }
+
+    @Override
+    public void accept(NodeVisitor visitor) {
+        visitor.visit(this);
+    }
+
+    @Override
+    public Map<?,?> evaluate(PebbleTemplateImpl self, EvaluationContext context) throws PebbleException {
+    	Map<Object,Object> returnEntries = new HashMap<>(Long.valueOf(Math.round(Math.ceil(entries.size() / 0.75))).intValue());
+    	for (Entry<Expression<?>,Expression<?>> entry : entries.entrySet()) {
+    		Expression<?> keyExpr = entry.getKey();
+    		Expression<?> valueExpr = entry.getValue();
+    		Object key = keyExpr == null ? null : keyExpr.evaluate(self, context);
+    		Object value = valueExpr == null ? null : valueExpr.evaluate(self, context);
+    		returnEntries.put(key, value);
+    	}
+        return returnEntries;
+    }
+
+}

--- a/src/main/java/com/mitchellbosecke/pebble/utils/OperatorUtils.java
+++ b/src/main/java/com/mitchellbosecke/pebble/utils/OperatorUtils.java
@@ -8,6 +8,9 @@
  ******************************************************************************/
 package com.mitchellbosecke.pebble.utils;
 
+import java.util.Collection;
+import java.util.List;
+
 /**
  * 
  * This class acts as a sort of wrapper around Java's built in operators. This
@@ -34,11 +37,18 @@ public class OperatorUtils {
     public static Object add(Object op1, Object op2) {
         if (op1 instanceof String || op2 instanceof String) {
             return concatenateStrings(String.valueOf(op1), String.valueOf(op2));
+        } else if (op1 instanceof List) {
+        	//FIXME should we offer this?
+            return addToList((List<?>)op1, op2);
         }
         return wideningConversionBinaryOperation(op1, op2, Operation.ADD);
     }
 
     public static Object subtract(Object op1, Object op2) {
+    	if (op1 instanceof List) {
+        	//FIXME should we offer this?
+            return subtractFromList((List<?>)op1, op2);
+        }
         return wideningConversionBinaryOperation(op1, op2, Operation.SUBTRACT);
     }
 
@@ -88,6 +98,25 @@ public class OperatorUtils {
 
     private static Object concatenateStrings(String op1, String op2) {
         return op1 + op2;
+    }
+
+    @SuppressWarnings({"unchecked","rawtypes"})
+	private static Object addToList(List<?> op1, Object op2) {
+    	if (op2 instanceof Collection) {
+    		op1.addAll((Collection)op2);
+    	} else {
+    		((List<Object>)op1).add(op2);
+    	}
+        return op1;
+    }
+    @SuppressWarnings({"unchecked","rawtypes"})
+	private static Object subtractFromList(List<?> op1, Object op2) {
+    	if (op2 instanceof Collection) {
+    		op1.removeAll((Collection)op2);
+    	} else {
+    		((List<Object>)op1).remove(op2);
+    	}
+        return op1;
     }
 
     private static Object wideningConversionBinaryOperation(Object op1, Object op2, Operation operation) {

--- a/src/main/java/com/mitchellbosecke/pebble/utils/OperatorUtils.java
+++ b/src/main/java/com/mitchellbosecke/pebble/utils/OperatorUtils.java
@@ -38,7 +38,7 @@ public class OperatorUtils {
         if (op1 instanceof String || op2 instanceof String) {
             return concatenateStrings(String.valueOf(op1), String.valueOf(op2));
         } else if (op1 instanceof List) {
-        	//FIXME should we offer this?
+        	//FIXME should overloading be supported?
             return addToList((List<?>)op1, op2);
         }
         return wideningConversionBinaryOperation(op1, op2, Operation.ADD);
@@ -46,7 +46,7 @@ public class OperatorUtils {
 
     public static Object subtract(Object op1, Object op2) {
     	if (op1 instanceof List) {
-        	//FIXME should we offer this?
+        	//FIXME should overloading be supported?
             return subtractFromList((List<?>)op1, op2);
         }
         return wideningConversionBinaryOperation(op1, op2, Operation.SUBTRACT);

--- a/src/test/java/com/mitchellbosecke/pebble/ArraySyntaxTest.java
+++ b/src/test/java/com/mitchellbosecke/pebble/ArraySyntaxTest.java
@@ -1,0 +1,683 @@
+/*******************************************************************************
+ * This file is part of Pebble.
+ *
+ * Copyright (c) 2014 by Mitchell Bösecke
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ ******************************************************************************/
+package com.mitchellbosecke.pebble;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.io.Writer;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Test;
+
+import com.mitchellbosecke.pebble.error.PebbleException;
+import com.mitchellbosecke.pebble.loader.Loader;
+import com.mitchellbosecke.pebble.loader.StringLoader;
+import com.mitchellbosecke.pebble.template.PebbleTemplate;
+
+public class ArraySyntaxTest extends AbstractTest {
+	
+	@Test
+	public void testArraySyntax() throws PebbleException, IOException {
+		Loader loader = new StringLoader();
+		PebbleEngine pebble = new PebbleEngine(loader);
+
+		String source = "{{ [] }}";
+		PebbleTemplate template = pebble.getTemplate(source);
+		
+		Writer writer = new StringWriter();
+		template.evaluate(writer, new HashMap<String, Object>());
+		assertEquals("[]", writer.toString());
+	}
+
+	@Test
+	public void testSimpleArray() throws PebbleException, IOException {
+		Loader loader = new StringLoader();
+		PebbleEngine pebble = new PebbleEngine(loader);
+
+		String source = "{{ ['first-name'] }}";
+		PebbleTemplate template = pebble.getTemplate(source);
+		
+		Writer writer = new StringWriter();
+		template.evaluate(writer, new HashMap<String, Object>());
+		assertEquals("[first-name]", writer.toString());
+	}
+
+	@Test
+	public void test2ElementArray() throws PebbleException, IOException {
+		Loader loader = new StringLoader();
+		PebbleEngine pebble = new PebbleEngine(loader);
+
+		String source = "{{ ['first-name','last-name'] }}";
+		PebbleTemplate template = pebble.getTemplate(source);
+		
+		Writer writer = new StringWriter();
+		template.evaluate(writer, new HashMap<String, Object>());
+		assertEquals("[first-name, last-name]", writer.toString());
+	}
+	@Test
+	public void test2ElementArray2() throws PebbleException, IOException {
+		Loader loader = new StringLoader();
+		PebbleEngine pebble = new PebbleEngine(loader);
+
+		String source = "{{ [ 'first-name' ,   'last-name'    ] }}";
+		PebbleTemplate template = pebble.getTemplate(source);
+		
+		Writer writer = new StringWriter();
+		template.evaluate(writer, new HashMap<String, Object>());
+		assertEquals("[first-name, last-name]", writer.toString());
+	}
+	@Test
+	public void testNElementArray() throws PebbleException, IOException {
+		Loader loader = new StringLoader();
+		PebbleEngine pebble = new PebbleEngine(loader);
+
+		String source = "{{ ['repeated-name','repeated-name','repeated-name','repeated-name','repeated-name','repeated-name','repeated-name'] }}";
+		PebbleTemplate template = pebble.getTemplate(source);
+		
+		Writer writer = new StringWriter();
+		template.evaluate(writer, new HashMap<String, Object>());
+		assertEquals("[repeated-name, repeated-name, repeated-name, repeated-name, repeated-name, repeated-name, repeated-name]", writer.toString());
+	}
+	
+	@SuppressWarnings("serial")
+	@Test
+	public void testArrayWithExpressions() throws PebbleException, IOException {
+		Loader loader = new StringLoader();
+		PebbleEngine pebble = new PebbleEngine(loader);
+
+		String source = "{{ ['one', 2, three, numbers['four']] }}";
+		PebbleTemplate template = pebble.getTemplate(source);
+
+		Map<String, Object> context = new HashMap<>();
+		context.put("three", "3");
+		context.put("numbers", new HashMap<String, Object>() {
+			{
+				put("four", "4");
+			}
+		});
+
+		Writer writer = new StringWriter();
+		template.evaluate(writer, context);
+		assertEquals("[one, 2, 3, 4]", writer.toString());
+	}
+	@SuppressWarnings({"serial","unused"})
+	@Test
+	public void testArrayWithComplexExpressions() throws PebbleException, IOException {
+		Loader loader = new StringLoader();
+		PebbleEngine pebble = new PebbleEngine(loader);
+
+		String source = "{{ ['one' + 'plus', 2 - 1, three.number, numbers['four'][0], numbers ['five'] .value ] }}";
+		PebbleTemplate template = pebble.getTemplate(source);
+
+		Map<String, Object> context = new HashMap<>();
+		context.put("three", new Object() { public Integer number = 3; });
+		context.put("numbers", new HashMap<String, Object>() {
+			{
+				put("four", new String[] {"4"});
+				put("five", new Object() { private String value = "five"; public String getValue() { return this.value; } });
+			}
+		});
+
+		Writer writer = new StringWriter();
+		template.evaluate(writer, context);
+		assertEquals("[oneplus, 1, 3, 4, five]", writer.toString());
+	}
+	
+	@Test
+	public void testSetCommand() throws PebbleException, IOException {
+		Loader loader = new StringLoader();
+		PebbleEngine pebble = new PebbleEngine(loader);
+
+		String source = "{% set arr = ['repeated-name',2*5] %}{{ arr }}";
+		PebbleTemplate template = pebble.getTemplate(source);
+		
+		Writer writer = new StringWriter();
+		template.evaluate(writer, new HashMap<String, Object>());
+		assertEquals("[repeated-name, 10]", writer.toString());
+	}
+	@Test
+	public void testSetCommand2() throws PebbleException, IOException {
+		Loader loader = new StringLoader();
+		PebbleEngine pebble = new PebbleEngine(loader);
+
+		String source = "{% set arr = ['repeated-name',2*5] %}{{ arr [1] }}";
+		PebbleTemplate template = pebble.getTemplate(source);
+		
+		Writer writer = new StringWriter();
+		template.evaluate(writer, new HashMap<String, Object>());
+		assertEquals("10", writer.toString());
+	}
+	
+	@Test
+	public void testFirstFilter() throws PebbleException, IOException {
+		Loader loader = new StringLoader();
+		PebbleEngine pebble = new PebbleEngine(loader);
+
+		String source = "{% set arr = ['name',2*5] %}{{ arr | first }}";
+		PebbleTemplate template = pebble.getTemplate(source);
+		
+		Writer writer = new StringWriter();
+		template.evaluate(writer, new HashMap<String, Object>());
+		assertEquals("name", writer.toString());
+	}
+	@Test
+	public void testFirstFilter2() throws PebbleException, IOException {
+		Loader loader = new StringLoader();
+		PebbleEngine pebble = new PebbleEngine(loader);
+
+		String source = "{{ ['name',2*5] | first }}";
+		PebbleTemplate template = pebble.getTemplate(source);
+		
+		Writer writer = new StringWriter();
+		template.evaluate(writer, new HashMap<String, Object>());
+		assertEquals("name", writer.toString());
+	}
+	
+	@Test
+	public void testJoinFilter() throws PebbleException, IOException {
+		Loader loader = new StringLoader();
+		PebbleEngine pebble = new PebbleEngine(loader);
+
+		String source = "{% set arr = ['name',2*5] %}{{ arr | join(':') }}";
+		PebbleTemplate template = pebble.getTemplate(source);
+		
+		Writer writer = new StringWriter();
+		template.evaluate(writer, new HashMap<String, Object>());
+		assertEquals("name:10", writer.toString());
+	}
+	@Test
+	public void testJoinFilter2() throws PebbleException, IOException {
+		Loader loader = new StringLoader();
+		PebbleEngine pebble = new PebbleEngine(loader);
+
+		String source = "{{ ['name',2*5] | join(':') }}";
+		PebbleTemplate template = pebble.getTemplate(source);
+		
+		Writer writer = new StringWriter();
+		template.evaluate(writer, new HashMap<String, Object>());
+		assertEquals("name:10", writer.toString());
+	}
+	
+	@Test
+	public void testLastFilter() throws PebbleException, IOException {
+		Loader loader = new StringLoader();
+		PebbleEngine pebble = new PebbleEngine(loader);
+
+		String source = "{% set arr = ['name',2*5] %}{{ arr | last }}";
+		PebbleTemplate template = pebble.getTemplate(source);
+		
+		Writer writer = new StringWriter();
+		template.evaluate(writer, new HashMap<String, Object>());
+		assertEquals("10", writer.toString());
+	}
+	@Test
+	public void testLastFilter2() throws PebbleException, IOException {
+		Loader loader = new StringLoader();
+		PebbleEngine pebble = new PebbleEngine(loader);
+
+		String source = "{{ ['name',2*5] | last }}";
+		PebbleTemplate template = pebble.getTemplate(source);
+		
+		Writer writer = new StringWriter();
+		template.evaluate(writer, new HashMap<String, Object>());
+		assertEquals("10", writer.toString());
+	}
+	
+	@Test
+	public void testSliceFilter() throws PebbleException, IOException {
+		Loader loader = new StringLoader();
+		PebbleEngine pebble = new PebbleEngine(loader);
+
+		String source = "{% set arr = ['name',2*5,'three',1.9] %}{{ arr | slice(1,3) }}";
+		PebbleTemplate template = pebble.getTemplate(source);
+		
+		Writer writer = new StringWriter();
+		template.evaluate(writer, new HashMap<String, Object>());
+		assertEquals("[10, three]", writer.toString());
+	}
+	@Test
+	public void testSliceFilter2() throws PebbleException, IOException {
+		Loader loader = new StringLoader();
+		PebbleEngine pebble = new PebbleEngine(loader);
+
+		String source = "{{ ['name',2*5,'three',1.9] | slice(1,3) }}";
+		PebbleTemplate template = pebble.getTemplate(source);
+		
+		Writer writer = new StringWriter();
+		template.evaluate(writer, new HashMap<String, Object>());
+		assertEquals("[10, three]", writer.toString());
+	}
+	
+	@Test
+	public void testSortFilter() throws PebbleException, IOException {
+		Loader loader = new StringLoader();
+		PebbleEngine pebble = new PebbleEngine(loader);
+
+		String source = "{% set arr = [3,2,1,0] %}{{ arr | sort }}";
+		PebbleTemplate template = pebble.getTemplate(source);
+		
+		Writer writer = new StringWriter();
+		template.evaluate(writer, new HashMap<String, Object>());
+		assertEquals("[0, 1, 2, 3]", writer.toString());
+	}
+	@Test
+	public void testSortFilter2() throws PebbleException, IOException {
+		Loader loader = new StringLoader();
+		PebbleEngine pebble = new PebbleEngine(loader);
+
+		String source = "{{ [3,2,1,0] | sort }}";
+		PebbleTemplate template = pebble.getTemplate(source);
+		
+		Writer writer = new StringWriter();
+		template.evaluate(writer, new HashMap<String, Object>());
+		assertEquals("[0, 1, 2, 3]", writer.toString());
+	}
+	
+	@Test
+	public void testForTag() throws PebbleException, IOException {
+		Loader loader = new StringLoader();
+		PebbleEngine pebble = new PebbleEngine(loader);
+
+		String source = "{% set names = ['Bob','Maria','John'] %}{% for name in names %}{{ name }}{% endfor %}";
+		PebbleTemplate template = pebble.getTemplate(source);
+		
+		Writer writer = new StringWriter();
+		template.evaluate(writer, new HashMap<String, Object>());
+		assertEquals("BobMariaJohn", writer.toString());
+	}
+	@Test
+	public void testForTag2() throws PebbleException, IOException {
+		Loader loader = new StringLoader();
+		PebbleEngine pebble = new PebbleEngine(loader);
+
+		String source = "{% for name in ['Bob','Maria','John'] %}{{ name }}{% endfor %}";
+		PebbleTemplate template = pebble.getTemplate(source);
+		
+		Writer writer = new StringWriter();
+		template.evaluate(writer, new HashMap<String, Object>());
+		assertEquals("BobMariaJohn", writer.toString());
+	}
+	@Test
+	public void testForElseTag() throws PebbleException, IOException {
+		Loader loader = new StringLoader();
+		PebbleEngine pebble = new PebbleEngine(loader);
+
+		String source = "{% for name in [] %}{{ name }}{% else %}{{ 'no name' }}{% endfor %}";
+		PebbleTemplate template = pebble.getTemplate(source);
+		
+		Writer writer = new StringWriter();
+		template.evaluate(writer, new HashMap<String, Object>());
+		assertEquals("no name", writer.toString());
+	}
+	
+	@Test
+	public void testIfTag() throws PebbleException, IOException {
+		Loader loader = new StringLoader();
+		PebbleEngine pebble = new PebbleEngine(loader);
+
+		String source = "{% set names = ['Bob','Maria','John'] %}{% if names is null %}{{ 'it is' }}{% else %}{{ 'it is not' }}{% endif %}";
+		PebbleTemplate template = pebble.getTemplate(source);
+		
+		Writer writer = new StringWriter();
+		template.evaluate(writer, new HashMap<String, Object>());
+		assertEquals("it is not", writer.toString());
+	}
+	@Test
+	public void testIfTag2() throws PebbleException, IOException {
+		Loader loader = new StringLoader();
+		PebbleEngine pebble = new PebbleEngine(loader);
+
+		String source = "{% if ['Bob','Maria','John'] is null %}{{ 'it is' }}{% else %}{{ 'it is not' }}{% endif %}";
+		PebbleTemplate template = pebble.getTemplate(source);
+		
+		Writer writer = new StringWriter();
+		template.evaluate(writer, new HashMap<String, Object>());
+		assertEquals("it is not", writer.toString());
+	}
+	
+	@Test
+	public void testMacroTag() throws PebbleException, IOException {
+		Loader loader = new StringLoader();
+		PebbleEngine pebble = new PebbleEngine(loader);
+
+		String source = "{% macro firstname(names) %}{{ names | first }}{% endmacro %}{{ firstname(['Bob','Maria','John']) }}";
+		PebbleTemplate template = pebble.getTemplate(source);
+		
+		Writer writer = new StringWriter();
+		template.evaluate(writer, new HashMap<String, Object>());
+		assertEquals("Bob", writer.toString());
+	}
+	
+	@Test
+	public void testNamedArgumentsMacroTag() throws PebbleException, IOException {
+		Loader loader = new StringLoader();
+		PebbleEngine pebble = new PebbleEngine(loader);
+
+		String source = "{% macro firstname(names) %}{{ names | first }}{% endmacro %}{{ firstname(names=['Bob','Maria','John']) }}";
+		PebbleTemplate template = pebble.getTemplate(source);
+		
+		Writer writer = new StringWriter();
+		template.evaluate(writer, new HashMap<String, Object>());
+		assertEquals("Bob", writer.toString());
+	}
+	
+	@Test
+	public void testAdditionOverloading() throws PebbleException, IOException {
+		Loader loader = new StringLoader();
+		PebbleEngine pebble = new PebbleEngine(loader);
+
+		String source = "{% set arr = [0,1] + 2 %}{{ arr }}";
+		PebbleTemplate template = pebble.getTemplate(source);
+		
+		Writer writer = new StringWriter();
+		template.evaluate(writer, new HashMap<String, Object>());
+		assertEquals("[0, 1, 2]", writer.toString());
+	}
+	@Test
+	public void testAdditionOverloading2() throws PebbleException, IOException {
+		Loader loader = new StringLoader();
+		PebbleEngine pebble = new PebbleEngine(loader);
+
+		String source = "{% set arr = [0,1] + [2,3] %}{{ arr }}";
+		PebbleTemplate template = pebble.getTemplate(source);
+		
+		Writer writer = new StringWriter();
+		template.evaluate(writer, new HashMap<String, Object>());
+		assertEquals("[0, 1, 2, 3]", writer.toString());
+	}
+	@Test(expected=RuntimeException.class)
+	public void testAdditionOverloading3() throws PebbleException, IOException {
+		Loader loader = new StringLoader();
+		PebbleEngine pebble = new PebbleEngine(loader);
+
+		String source = "{% set arr = 1 + [0,1] %}{{ arr }}";
+		PebbleTemplate template = pebble.getTemplate(source);
+		
+		Writer writer = new StringWriter();
+		template.evaluate(writer, new HashMap<String, Object>());
+	}
+	
+	@Test
+	public void testSubtractionOverloading() throws PebbleException, IOException {
+		Loader loader = new StringLoader();
+		PebbleEngine pebble = new PebbleEngine(loader);
+
+		String source = "{% set arr = [0,1,2] - 1 %}{{ arr }}";
+		PebbleTemplate template = pebble.getTemplate(source);
+		
+		Writer writer = new StringWriter();
+		template.evaluate(writer, new HashMap<String, Object>());
+		assertEquals("[0, 2]", writer.toString());
+	}
+	@Test
+	public void testSubtractionOverloading2() throws PebbleException, IOException {
+		Loader loader = new StringLoader();
+		PebbleEngine pebble = new PebbleEngine(loader);
+
+		String source = "{% set arr = [0,1,2] - [0,2,3] %}{{ arr }}";
+		PebbleTemplate template = pebble.getTemplate(source);
+		
+		Writer writer = new StringWriter();
+		template.evaluate(writer, new HashMap<String, Object>());
+		assertEquals("[1]", writer.toString());
+	}
+	@Test(expected=RuntimeException.class)
+	public void testSubtractionOverloading3() throws PebbleException, IOException {
+		Loader loader = new StringLoader();
+		PebbleEngine pebble = new PebbleEngine(loader);
+
+		String source = "{% set arr = 1 - [0,2] %}{{ arr }}";
+		PebbleTemplate template = pebble.getTemplate(source);
+		
+		Writer writer = new StringWriter();
+		template.evaluate(writer, new HashMap<String, Object>());
+	}
+	
+	@Test
+	public void testEmptyTest() throws PebbleException, IOException {
+		Loader loader = new StringLoader();
+		PebbleEngine pebble = new PebbleEngine(loader);
+
+		String source = "{% set arr = [0,1,2] %}{% if arr is empty %}{{ 'true' }}{% else %}{{ 'false' }}{% endif %}";
+		PebbleTemplate template = pebble.getTemplate(source);
+		
+		Writer writer = new StringWriter();
+		template.evaluate(writer, new HashMap<String, Object>());
+		assertEquals("false", writer.toString());
+	}
+	@Test
+	public void testEmptyTest2() throws PebbleException, IOException {
+		Loader loader = new StringLoader();
+		PebbleEngine pebble = new PebbleEngine(loader);
+
+		String source = "{% if [0,1,2] is empty %}{{ 'true' }}{% else %}{{ 'false' }}{% endif %}";
+		PebbleTemplate template = pebble.getTemplate(source);
+		
+		Writer writer = new StringWriter();
+		template.evaluate(writer, new HashMap<String, Object>());
+		assertEquals("false", writer.toString());
+	}
+	@Test
+	public void testEmptyTest3() throws PebbleException, IOException {
+		Loader loader = new StringLoader();
+		PebbleEngine pebble = new PebbleEngine(loader);
+
+		String source = "{% if [] is not empty %}{{ 'true' }}{% else %}{{ 'false' }}{% endif %}";
+		PebbleTemplate template = pebble.getTemplate(source);
+		
+		Writer writer = new StringWriter();
+		template.evaluate(writer, new HashMap<String, Object>());
+		assertEquals("false", writer.toString());
+	}
+	
+	@Test
+	public void testIterableTest() throws PebbleException, IOException {
+		Loader loader = new StringLoader();
+		PebbleEngine pebble = new PebbleEngine(loader);
+
+		String source = "{% set arr = [0,1,2] %}{% if arr is iterable %}{{ 'true' }}{% endif %}";
+		PebbleTemplate template = pebble.getTemplate(source);
+		
+		Writer writer = new StringWriter();
+		template.evaluate(writer, new HashMap<String, Object>());
+		assertEquals("true", writer.toString());
+	}
+	@Test
+	public void testIterableTest2() throws PebbleException, IOException {
+		Loader loader = new StringLoader();
+		PebbleEngine pebble = new PebbleEngine(loader);
+
+		String source = "{% if [0,1,2] is iterable %}{{ 'true' }}{% endif %}";
+		PebbleTemplate template = pebble.getTemplate(source);
+		
+		Writer writer = new StringWriter();
+		template.evaluate(writer, new HashMap<String, Object>());
+		assertEquals("true", writer.toString());
+	}
+	
+	@Test
+	public void testContainsOperator() throws PebbleException, IOException {
+		Loader loader = new StringLoader();
+		PebbleEngine pebble = new PebbleEngine(loader);
+
+		String source = "{% set arr = [0,1,2] %}{% if arr contains 1 %}true{% endif %}";
+		PebbleTemplate template = pebble.getTemplate(source);
+		
+		Writer writer = new StringWriter();
+		template.evaluate(writer, new HashMap<String, Object>());
+		assertEquals("true", writer.toString());
+	}
+	@Test
+	public void testContainsOperator2() throws PebbleException, IOException {
+		Loader loader = new StringLoader();
+		PebbleEngine pebble = new PebbleEngine(loader);
+
+		String source = "{% if [0,1,2] contains 1 %}true{% endif %}";
+		PebbleTemplate template = pebble.getTemplate(source);
+		
+		Writer writer = new StringWriter();
+		template.evaluate(writer, new HashMap<String, Object>());
+		assertEquals("true", writer.toString());
+	}
+	@Test
+	public void testContainsOperator3() throws PebbleException, IOException {
+		Loader loader = new StringLoader();
+		PebbleEngine pebble = new PebbleEngine(loader);
+
+		String source = "{% if [0,1,2] contains [1,2] %}true{% endif %}";
+		PebbleTemplate template = pebble.getTemplate(source);
+		
+		Writer writer = new StringWriter();
+		template.evaluate(writer, new HashMap<String, Object>());
+		assertEquals("true", writer.toString());
+	}
+	@Test
+	public void testContainsOperator4() throws PebbleException, IOException {
+		Loader loader = new StringLoader();
+		PebbleEngine pebble = new PebbleEngine(loader);
+
+		String source = "{% if not [0,1,2] contains 10 %}true{% endif %}";
+		PebbleTemplate template = pebble.getTemplate(source);
+		
+		Writer writer = new StringWriter();
+		template.evaluate(writer, new HashMap<String, Object>());
+		assertEquals("true", writer.toString());
+	}
+	@Test
+	public void testContainsOperator5() throws PebbleException, IOException {
+		Loader loader = new StringLoader();
+		PebbleEngine pebble = new PebbleEngine(loader);
+
+		String source = "{% if [0,1,2] contains 1 and not [0,1] contains 0 %}true{% else %}false{% endif %}";
+		PebbleTemplate template = pebble.getTemplate(source);
+		
+		Writer writer = new StringWriter();
+		template.evaluate(writer, new HashMap<String, Object>());
+		assertEquals("false", writer.toString());
+	}
+	
+	
+	
+	
+	// subscript syntax regression tests
+	
+	@SuppressWarnings("serial")
+	@Test
+	public void testProblematicSubscriptSyntax() throws PebbleException, IOException {
+		Loader loader = new StringLoader();
+		PebbleEngine pebble = new PebbleEngine(loader);
+		pebble.setStrictVariables(false);
+
+		String source = "{{ person ['first-name'] }}";
+		PebbleTemplate template = pebble.getTemplate(source);
+
+		Map<String, Object> context = new HashMap<>();
+		context.put("person", new HashMap<String, Object>() {
+			{
+				put("first-name", "Bob");
+			}
+		});
+
+		Writer writer = new StringWriter();
+		template.evaluate(writer, context);
+		assertEquals("Bob", writer.toString());
+	}
+
+	@SuppressWarnings("serial")
+	@Test
+	public void testProblematicSubscriptSyntax2() throws PebbleException, IOException {
+		Loader loader = new StringLoader();
+		PebbleEngine pebble = new PebbleEngine(loader);
+		pebble.setStrictVariables(false);
+
+		String source = "{{ person ['first-name'][0] }}";
+		PebbleTemplate template = pebble.getTemplate(source);
+
+		Map<String, Object> context = new HashMap<>();
+		context.put("person", new HashMap<String, Object>() {
+			{
+				put("first-name", new String[] {"Bob"});
+			}
+		});
+
+		Writer writer = new StringWriter();
+		template.evaluate(writer, context);
+		assertEquals("Bob", writer.toString());
+	}
+
+	@SuppressWarnings({"serial","unused"})
+	@Test
+	public void testProblematicSubscriptSyntax3() throws PebbleException, IOException {
+		Loader loader = new StringLoader();
+		PebbleEngine pebble = new PebbleEngine(loader);
+		pebble.setStrictVariables(false);
+
+		String source = "{{ person ['first-name'] .name }}";
+		PebbleTemplate template = pebble.getTemplate(source);
+
+		Map<String, Object> context = new HashMap<>();
+		context.put("person", new HashMap<String, Object>() {
+			{
+				put("first-name", new Object() { private String name = "Bob"; public String getName() { return this.name; } });
+			}
+		});
+
+		Writer writer = new StringWriter();
+		template.evaluate(writer, context);
+		assertEquals("Bob", writer.toString());
+	}
+
+	@SuppressWarnings("serial")
+	@Test
+	public void testProblematicSubscriptSyntax4() throws PebbleException, IOException {
+		Loader loader = new StringLoader();
+		PebbleEngine pebble = new PebbleEngine(loader);
+		pebble.setStrictVariables(false);
+
+		String source = "{% if person ['first-name'] == 'Bob' %}{{ person ['first-name'] }}{% endif %}";
+		PebbleTemplate template = pebble.getTemplate(source);
+
+		Map<String, Object> context = new HashMap<>();
+		context.put("person", new HashMap<String, Object>() {
+			{
+				put("first-name", "Bob");
+			}
+		});
+
+		Writer writer = new StringWriter();
+		template.evaluate(writer, context);
+		assertEquals("Bob", writer.toString());
+	}
+	
+	@SuppressWarnings("serial")
+	@Test
+	public void testProblematicSubscriptSyntax5() throws PebbleException, IOException {
+		Loader loader = new StringLoader();
+		PebbleEngine pebble = new PebbleEngine(loader);
+		pebble.setStrictVariables(false);
+
+		String source = "{% set name = person ['first-name'] %}{{ name }}";
+		PebbleTemplate template = pebble.getTemplate(source);
+
+		Map<String, Object> context = new HashMap<>();
+		context.put("person", new HashMap<String, Object>() {
+			{
+				put("first-name", "Bob");
+			}
+		});
+
+		Writer writer = new StringWriter();
+		template.evaluate(writer, context);
+		assertEquals("Bob", writer.toString());
+	}
+	
+}

--- a/src/test/java/com/mitchellbosecke/pebble/ArraySyntaxTest.java
+++ b/src/test/java/com/mitchellbosecke/pebble/ArraySyntaxTest.java
@@ -18,6 +18,7 @@ import java.util.Map;
 
 import org.junit.Test;
 
+import com.mitchellbosecke.pebble.error.ParserException;
 import com.mitchellbosecke.pebble.error.PebbleException;
 import com.mitchellbosecke.pebble.loader.Loader;
 import com.mitchellbosecke.pebble.loader.StringLoader;
@@ -86,6 +87,18 @@ public class ArraySyntaxTest extends AbstractTest {
 		Writer writer = new StringWriter();
 		template.evaluate(writer, new HashMap<String, Object>());
 		assertEquals("[repeated-name, repeated-name, repeated-name, repeated-name, repeated-name, repeated-name, repeated-name]", writer.toString());
+	}
+	
+	@Test(expected=ParserException.class)
+	public void testIncompleteArraySyntax() throws PebbleException, IOException {
+		Loader loader = new StringLoader();
+		PebbleEngine pebble = new PebbleEngine(loader);
+
+		String source = "{{ [,] }}";
+		PebbleTemplate template = pebble.getTemplate(source);
+		
+		Writer writer = new StringWriter();
+		template.evaluate(writer, new HashMap<String, Object>());
 	}
 	
 	@SuppressWarnings("serial")

--- a/src/test/java/com/mitchellbosecke/pebble/ArraySyntaxTest.java
+++ b/src/test/java/com/mitchellbosecke/pebble/ArraySyntaxTest.java
@@ -565,6 +565,43 @@ public class ArraySyntaxTest extends AbstractTest {
 		assertEquals("false", writer.toString());
 	}
 	
+	@Test
+	public void testNestedArrays() throws PebbleException, IOException {
+		Loader loader = new StringLoader();
+		PebbleEngine pebble = new PebbleEngine(loader);
+
+		String source = "{% set arr = [[]] %}{{ arr }}";
+		PebbleTemplate template = pebble.getTemplate(source);
+		
+		Writer writer = new StringWriter();
+		template.evaluate(writer, new HashMap<String, Object>());
+		assertEquals("[[]]", writer.toString());
+	}
+	@Test
+	public void testNestedArrays2() throws PebbleException, IOException {
+		Loader loader = new StringLoader();
+		PebbleEngine pebble = new PebbleEngine(loader);
+
+		String source = "{% set arr = [[],['test'],[['nested'],['arrays']]] %}{{ arr }}";
+		PebbleTemplate template = pebble.getTemplate(source);
+		
+		Writer writer = new StringWriter();
+		template.evaluate(writer, new HashMap<String, Object>());
+		assertEquals("[[], [test], [[nested], [arrays]]]", writer.toString());
+	}
+	@Test
+	public void testNestedArrays3() throws PebbleException, IOException {
+		Loader loader = new StringLoader();
+		PebbleEngine pebble = new PebbleEngine(loader);
+
+		String source = "{{ [[],['test'],[['nested'],['arrays']]] }}";
+		PebbleTemplate template = pebble.getTemplate(source);
+		
+		Writer writer = new StringWriter();
+		template.evaluate(writer, new HashMap<String, Object>());
+		assertEquals("[[], [test], [[nested], [arrays]]]", writer.toString());
+	}
+	
 	
 	
 	

--- a/src/test/java/com/mitchellbosecke/pebble/ArraySyntaxTest.java
+++ b/src/test/java/com/mitchellbosecke/pebble/ArraySyntaxTest.java
@@ -369,9 +369,8 @@ public class ArraySyntaxTest extends AbstractTest {
 		template.evaluate(writer, new HashMap<String, Object>());
 		assertEquals("Bob", writer.toString());
 	}
-	
 	@Test
-	public void testNamedArgumentsMacroTag() throws PebbleException, IOException {
+	public void testMacroTagNamedArguments() throws PebbleException, IOException {
 		Loader loader = new StringLoader();
 		PebbleEngine pebble = new PebbleEngine(loader);
 
@@ -613,6 +612,19 @@ public class ArraySyntaxTest extends AbstractTest {
 		Writer writer = new StringWriter();
 		template.evaluate(writer, new HashMap<String, Object>());
 		assertEquals("[[], [test], [[nested], [arrays]]]", writer.toString());
+	}
+	
+	@Test
+	public void testNestedMapInArray() throws PebbleException, IOException {
+		Loader loader = new StringLoader();
+		PebbleEngine pebble = new PebbleEngine(loader);
+
+		String source = "{{ [{1:1}] }}";
+		PebbleTemplate template = pebble.getTemplate(source);
+		
+		Writer writer = new StringWriter();
+		template.evaluate(writer, new HashMap<String, Object>());
+		assertEquals("[{1=1}]", writer.toString());
 	}
 	
 	

--- a/src/test/java/com/mitchellbosecke/pebble/CoreFiltersTest.java
+++ b/src/test/java/com/mitchellbosecke/pebble/CoreFiltersTest.java
@@ -12,6 +12,8 @@ import com.mitchellbosecke.pebble.error.PebbleException;
 import com.mitchellbosecke.pebble.loader.Loader;
 import com.mitchellbosecke.pebble.loader.StringLoader;
 import com.mitchellbosecke.pebble.template.PebbleTemplate;
+
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -616,6 +618,144 @@ public class CoreFiltersTest extends AbstractTest {
         public String getUsername() {
             return username;
         }
+    }
+
+    @Test
+    public void testSliceWithNullInput() throws PebbleException, IOException {
+        Loader loader = new StringLoader();
+        PebbleEngine pebble = new PebbleEngine(loader);
+
+        PebbleTemplate template = pebble.getTemplate("{{ null | slice }}");
+        
+        Map<String, Object> context = new HashMap<>();
+
+        Writer writer = new StringWriter();
+        template.evaluate(writer, context);
+        assertEquals("", writer.toString());
+    }
+
+    @Test(expected=IllegalArgumentException.class)
+    public void testSliceWithNoArgs() throws PebbleException, IOException {
+        Loader loader = new StringLoader();
+        PebbleEngine pebble = new PebbleEngine(loader);
+
+        PebbleTemplate template = pebble.getTemplate("{{ name | slice }}");
+        
+        Map<String, Object> context = new HashMap<>();
+        context.put("name", "Alex");
+
+        Writer writer = new StringWriter();
+        template.evaluate(writer, context);
+    }
+
+    @Test(expected=IllegalArgumentException.class)
+    public void testSliceWithInvalidFirstArg() throws PebbleException, IOException {
+        Loader loader = new StringLoader();
+        PebbleEngine pebble = new PebbleEngine(loader);
+
+        PebbleTemplate template = pebble.getTemplate("{{ name | slice(-1) }}");
+        
+        Map<String, Object> context = new HashMap<>();
+        context.put("name", "Alex");
+
+        Writer writer = new StringWriter();
+        template.evaluate(writer, context);
+    }
+
+    @Test(expected=IllegalArgumentException.class)
+    public void testSliceWithInvalidSecondArg() throws PebbleException, IOException {
+        Loader loader = new StringLoader();
+        PebbleEngine pebble = new PebbleEngine(loader);
+
+        PebbleTemplate template = pebble.getTemplate("{{ name | slice(0,-1) }}");
+        
+        Map<String, Object> context = new HashMap<>();
+        context.put("name", "Alex");
+
+        Writer writer = new StringWriter();
+        template.evaluate(writer, context);
+    }
+
+    @Test(expected=IllegalArgumentException.class)
+    public void testSliceWithInvalidSecondArg2() throws PebbleException, IOException {
+        Loader loader = new StringLoader();
+        PebbleEngine pebble = new PebbleEngine(loader);
+
+        PebbleTemplate template = pebble.getTemplate("{{ name | slice(0,1000) }}");
+        
+        Map<String, Object> context = new HashMap<>();
+        context.put("name", "Alex");
+
+        Writer writer = new StringWriter();
+        template.evaluate(writer, context);
+    }
+
+    @Test
+    public void testSliceWithString() throws PebbleException, IOException {
+        Loader loader = new StringLoader();
+        PebbleEngine pebble = new PebbleEngine(loader);
+
+        PebbleTemplate template = pebble.getTemplate("{{ name | slice(2,5) }}");
+        
+        Map<String, Object> context = new HashMap<>();
+        context.put("name", "Alexander");
+
+        Writer writer = new StringWriter();
+        template.evaluate(writer, context);
+        assertEquals("exa", writer.toString());
+    }
+
+    @Test
+    public void testSliceWithList() throws PebbleException, IOException {
+        Loader loader = new StringLoader();
+        PebbleEngine pebble = new PebbleEngine(loader);
+
+        PebbleTemplate template = pebble.getTemplate("{{ names | slice(2,5) }}");
+        
+        List<String> names = new ArrayList<>();
+        names.add("Alex");
+        names.add("Joe");
+        names.add("Bob");
+        names.add("Sarah");
+        names.add("Mary");
+        names.add("Marge");
+        Map<String, Object> context = new HashMap<>();
+        context.put("names", names);
+
+        Writer writer = new StringWriter();
+        template.evaluate(writer, context);
+        assertEquals("[Bob, Sarah, Mary]", writer.toString());
+    }
+
+    @Ignore
+    @Test
+    public void testSliceWithArray() throws PebbleException, IOException {
+        Loader loader = new StringLoader();
+        PebbleEngine pebble = new PebbleEngine(loader);
+
+        PebbleTemplate template = pebble.getTemplate("{{ names | slice(2,5) }}");
+        
+        String[] names = new String[] {"Alex", "Joe", "Bob", "Sarah", "Mary", "Marge"};
+        Map<String, Object> context = new HashMap<>();
+        context.put("names", names);
+
+        Writer writer = new StringWriter();
+        template.evaluate(writer, context);
+        assertEquals("[Bob, Sarah, Mary]", writer.toString());
+    }
+
+    @Test(expected=IllegalArgumentException.class)
+    public void testSliceWithInvalidInputType() throws PebbleException, IOException {
+        Loader loader = new StringLoader();
+        PebbleEngine pebble = new PebbleEngine(loader);
+
+        PebbleTemplate template = pebble.getTemplate("{{ names | slice(2,5) }}");
+        
+        Map<String, Object> context = new HashMap<>();
+        context.put("names", Long.valueOf(1));
+
+        Writer writer = new StringWriter();
+        template.evaluate(writer, context);
     }
 
 }

--- a/src/test/java/com/mitchellbosecke/pebble/CoreFiltersTest.java
+++ b/src/test/java/com/mitchellbosecke/pebble/CoreFiltersTest.java
@@ -8,13 +8,7 @@
  ******************************************************************************/
 package com.mitchellbosecke.pebble;
 
-import com.mitchellbosecke.pebble.error.PebbleException;
-import com.mitchellbosecke.pebble.loader.Loader;
-import com.mitchellbosecke.pebble.loader.StringLoader;
-import com.mitchellbosecke.pebble.template.PebbleTemplate;
-
-import org.junit.Ignore;
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
 import java.io.StringWriter;
@@ -22,9 +16,20 @@ import java.io.Writer;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import com.mitchellbosecke.pebble.error.PebbleException;
+import com.mitchellbosecke.pebble.loader.Loader;
+import com.mitchellbosecke.pebble.loader.StringLoader;
+import com.mitchellbosecke.pebble.template.PebbleTemplate;
 
 public class CoreFiltersTest extends AbstractTest {
 
@@ -634,8 +639,8 @@ public class CoreFiltersTest extends AbstractTest {
         assertEquals("", writer.toString());
     }
 
-    @Test(expected=IllegalArgumentException.class)
-    public void testSliceWithNoArgs() throws PebbleException, IOException {
+    @Test
+    public void testSliceWithDefaultArgs() throws PebbleException, IOException {
         Loader loader = new StringLoader();
         PebbleEngine pebble = new PebbleEngine(loader);
 
@@ -646,6 +651,7 @@ public class CoreFiltersTest extends AbstractTest {
 
         Writer writer = new StringWriter();
         template.evaluate(writer, context);
+        assertEquals("Alex", writer.toString());
     }
 
     @Test(expected=IllegalArgumentException.class)
@@ -727,13 +733,12 @@ public class CoreFiltersTest extends AbstractTest {
         assertEquals("[Bob, Sarah, Mary]", writer.toString());
     }
 
-    @Ignore
     @Test
-    public void testSliceWithArray() throws PebbleException, IOException {
+    public void testSliceWithStringArray() throws PebbleException, IOException {
         Loader loader = new StringLoader();
         PebbleEngine pebble = new PebbleEngine(loader);
 
-        PebbleTemplate template = pebble.getTemplate("{{ names | slice(2,5) }}");
+        PebbleTemplate template = pebble.getTemplate("{% set n = names | slice(2,5) %}{{ n[0] }}");
         
         String[] names = new String[] {"Alex", "Joe", "Bob", "Sarah", "Mary", "Marge"};
         Map<String, Object> context = new HashMap<>();
@@ -741,7 +746,67 @@ public class CoreFiltersTest extends AbstractTest {
 
         Writer writer = new StringWriter();
         template.evaluate(writer, context);
-        assertEquals("[Bob, Sarah, Mary]", writer.toString());
+        assertEquals("Bob", writer.toString());
+    }
+    //FIXME primitive values are not printed to output
+    // maybe test with contains test?
+    @Ignore
+    @Test
+    public void testSliceWithPrimitivesArray() throws PebbleException, IOException {
+        Loader loader = new StringLoader();
+        PebbleEngine pebble = new PebbleEngine(loader);
+
+        PebbleTemplate template = pebble.getTemplate("{% set p = primitives | slice(2,5) %}{{ p[0] }}");
+        Map<String, Object> context = new HashMap<>();
+        Writer writer = new StringWriter();
+
+        // boolean
+        boolean[] booleans = new boolean[] {true, false, true, false, true, false};
+        context.put("primitives", booleans);
+        template.evaluate(writer, context);
+        assertEquals("true", writer.toString());
+
+        // byte
+        byte[] bytes = new byte[] {0, 1, 2, 3, 4, 5};
+        context.put("primitives", bytes);
+        template.evaluate(writer, context);
+        assertEquals("2", writer.toString());
+
+        // char
+        char[] chars = new char[] {'a', 'b', 'c', 'd', 'e', 'f'};
+        context.put("primitives", chars);
+        template.evaluate(writer, context);
+        assertEquals("c", writer.toString());
+
+        // double
+        double[] doubles = new double[] {0.0d, 1.0d, 2.0d, 3.0d, 4.0d, 5.0d};
+        context.put("primitives", doubles);
+        template.evaluate(writer, context);
+        assertEquals("2.0", writer.toString());
+
+        // float
+        float[] floats = new float[] {0.0f, 1.0f, 2.0f, 3.0f, 4.0f, 5.0f};
+        context.put("primitives", floats);
+        template.evaluate(writer, context);
+        assertEquals("2.0", writer.toString());
+
+        // int
+        int[] ints = new int[] {0, 1, 2, 3, 4, 5};
+        context.put("primitives", ints);
+        template.evaluate(writer, context);
+        assertEquals("2", writer.toString());
+
+        // long
+        long[] longs = new long[] {0, 1, 2, 3, 4, 5};
+        context.put("primitives", longs);
+        template.evaluate(writer, context);
+        assertEquals("2", writer.toString());
+
+        // short
+        short[] shorts = new short[] {0, 1, 2, 3, 4, 5};
+        context.put("primitives", shorts);
+        template.evaluate(writer, context);
+        assertEquals("2", writer.toString());
     }
 
     @Test(expected=IllegalArgumentException.class)

--- a/src/test/java/com/mitchellbosecke/pebble/CoreFiltersTest.java
+++ b/src/test/java/com/mitchellbosecke/pebble/CoreFiltersTest.java
@@ -758,51 +758,59 @@ public class CoreFiltersTest extends AbstractTest {
 
         PebbleTemplate template = pebble.getTemplate("{% set p = primitives | slice(2,5) %}{{ p[0] }}");
         Map<String, Object> context = new HashMap<>();
-        Writer writer = new StringWriter();
+        Writer writer;
 
         // boolean
+        writer = new StringWriter();
         boolean[] booleans = new boolean[] {true, false, true, false, true, false};
         context.put("primitives", booleans);
         template.evaluate(writer, context);
         assertEquals("true", writer.toString());
 
         // byte
+        writer = new StringWriter();
         byte[] bytes = new byte[] {0, 1, 2, 3, 4, 5};
         context.put("primitives", bytes);
         template.evaluate(writer, context);
         assertEquals("2", writer.toString());
 
         // char
+        writer = new StringWriter();
         char[] chars = new char[] {'a', 'b', 'c', 'd', 'e', 'f'};
         context.put("primitives", chars);
         template.evaluate(writer, context);
         assertEquals("c", writer.toString());
 
         // double
+        writer = new StringWriter();
         double[] doubles = new double[] {0.0d, 1.0d, 2.0d, 3.0d, 4.0d, 5.0d};
         context.put("primitives", doubles);
         template.evaluate(writer, context);
         assertEquals("2.0", writer.toString());
 
         // float
+        writer = new StringWriter();
         float[] floats = new float[] {0.0f, 1.0f, 2.0f, 3.0f, 4.0f, 5.0f};
         context.put("primitives", floats);
         template.evaluate(writer, context);
         assertEquals("2.0", writer.toString());
 
         // int
+        writer = new StringWriter();
         int[] ints = new int[] {0, 1, 2, 3, 4, 5};
         context.put("primitives", ints);
         template.evaluate(writer, context);
         assertEquals("2", writer.toString());
 
         // long
+        writer = new StringWriter();
         long[] longs = new long[] {0, 1, 2, 3, 4, 5};
         context.put("primitives", longs);
         template.evaluate(writer, context);
         assertEquals("2", writer.toString());
 
         // short
+        writer = new StringWriter();
         short[] shorts = new short[] {0, 1, 2, 3, 4, 5};
         context.put("primitives", shorts);
         template.evaluate(writer, context);

--- a/src/test/java/com/mitchellbosecke/pebble/CoreOperatorsTest.java
+++ b/src/test/java/com/mitchellbosecke/pebble/CoreOperatorsTest.java
@@ -19,7 +19,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.Ignore;
 import org.junit.Test;
 
 import com.mitchellbosecke.pebble.error.PebbleException;
@@ -386,22 +385,6 @@ public class CoreOperatorsTest extends AbstractTest {
 		template.evaluate(writer, context);
 		assertEquals("yes", writer.toString());
 	}
-	@Ignore
-	@Test
-	public void testContainsOperator3() throws PebbleException, IOException {
-		Loader loader = new StringLoader();
-		PebbleEngine pebble = new PebbleEngine(loader);
-
-		String source = "{% if values contains 1 %}yes{% else %}no{% endif %}";
-		PebbleTemplate template = pebble.getTemplate(source);
-		
-		Map<String, Object> context = new HashMap<>();
-		context.put("values", new int[] {1,2});
-		
-		Writer writer = new StringWriter();
-		template.evaluate(writer, context);
-		assertEquals("yes", writer.toString());
-	}
 	@Test
 	public void testContainsOperator4() throws PebbleException, IOException {
 		Loader loader = new StringLoader();
@@ -459,6 +442,79 @@ public class CoreOperatorsTest extends AbstractTest {
 		context.put("names", Arrays.asList("Bob", "Maria", "John"));
 
 		Writer writer = new StringWriter();
+		template.evaluate(writer, context);
+		assertEquals("yes", writer.toString());
+	}
+	@Test
+	public void testContainsWithArrays() throws PebbleException, IOException {
+		Loader loader = new StringLoader();
+		PebbleEngine pebble = new PebbleEngine(loader);
+
+		String source = "{% if values contains value %}yes{% else %}no{% endif %}";
+		PebbleTemplate template = pebble.getTemplate(source);
+		Map<String, Object> context = new HashMap<>();
+		Writer writer;
+
+		// Objects
+		writer = new StringWriter();
+		context.put("values", new String[] {"Bob","Marley"});
+		context.put("value", "Bob");
+		template.evaluate(writer, context);
+		assertEquals("yes", writer.toString());
+
+		// boolean
+		writer = new StringWriter();
+		context.put("values", new boolean[] {true,false});
+		context.put("value", Boolean.TRUE);
+		template.evaluate(writer, context);
+		assertEquals("yes", writer.toString());
+
+		// byte
+		writer = new StringWriter();
+		context.put("values", new byte[] {1,2});
+		context.put("value", Byte.valueOf("1"));
+		template.evaluate(writer, context);
+		assertEquals("yes", writer.toString());
+
+		// char
+		writer = new StringWriter();
+		context.put("values", new char[] {'a','b'});
+		context.put("value", new Character('a'));
+		template.evaluate(writer, context);
+		assertEquals("yes", writer.toString());
+
+		// double
+		writer = new StringWriter();
+		context.put("values", new double[] {1.0d,2.0d});
+		context.put("value", new Double(1.0d));
+		template.evaluate(writer, context);
+		assertEquals("yes", writer.toString());
+
+		// float
+		writer = new StringWriter();
+		context.put("values", new float[] {1.0f,2.0f});
+		context.put("value", new Float(1.0f));
+		template.evaluate(writer, context);
+		assertEquals("yes", writer.toString());
+
+		// int
+		writer = new StringWriter();
+		context.put("values", new int[] {1,2});
+		context.put("value", new Integer(1));
+		template.evaluate(writer, context);
+		assertEquals("yes", writer.toString());
+
+		// long
+		writer = new StringWriter();
+		context.put("values", new long[] {1,2});
+		context.put("value", new Long(1));
+		template.evaluate(writer, context);
+		assertEquals("yes", writer.toString());
+
+		// short
+		writer = new StringWriter();
+		context.put("values", new short[] {1,2});
+		context.put("value", Short.valueOf("1"));
 		template.evaluate(writer, context);
 		assertEquals("yes", writer.toString());
 	}

--- a/src/test/java/com/mitchellbosecke/pebble/CoreOperatorsTest.java
+++ b/src/test/java/com/mitchellbosecke/pebble/CoreOperatorsTest.java
@@ -14,10 +14,12 @@ import java.io.IOException;
 import java.io.StringWriter;
 import java.io.Writer;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.junit.Ignore;
 import org.junit.Test;
 
 import com.mitchellbosecke.pebble.error.PebbleException;
@@ -334,4 +336,131 @@ public class CoreOperatorsTest extends AbstractTest {
 		template.evaluate(writer);
 		assertEquals(" true ", writer.toString());
 	}
+	
+	@Test
+	public void testContainsOperator() throws PebbleException, IOException {
+		Loader loader = new StringLoader();
+		PebbleEngine pebble = new PebbleEngine(loader);
+
+		String source = "{% if names contains 'John' %}yes{% else %}no{% endif %}";
+		PebbleTemplate template = pebble.getTemplate(source);
+		
+		Map<String, Object> context = new HashMap<>();
+		context.put("names", Arrays.asList("Bob", "Maria", "John"));
+
+		Writer writer = new StringWriter();
+		template.evaluate(writer, context);
+		assertEquals("yes", writer.toString());
+	}
+	@Test
+	public void testContainsOperatorWithNull() throws PebbleException, IOException {
+		Loader loader = new StringLoader();
+		PebbleEngine pebble = new PebbleEngine(loader);
+
+		String source = "{% if null contains 'John' %}yes{% else %}no{% endif %}";
+		PebbleTemplate template = pebble.getTemplate(source);
+		
+		Writer writer = new StringWriter();
+		template.evaluate(writer);
+		assertEquals("no", writer.toString());
+	}
+	@SuppressWarnings("serial")
+	@Test
+	public void testContainsOperator2() throws PebbleException, IOException {
+		Loader loader = new StringLoader();
+		PebbleEngine pebble = new PebbleEngine(loader);
+
+		String source = "{% if names contains 'Maria' %}yes{% else %}no{% endif %}";
+		PebbleTemplate template = pebble.getTemplate(source);
+		
+		Map<String, Object> context = new HashMap<>();
+		context.put("names", new HashMap<String,String>() {
+			{
+				put("Bob","Bob");
+				put("Maria","Maria");
+				put("John","John");
+			}
+		});
+		
+		Writer writer = new StringWriter();
+		template.evaluate(writer, context);
+		assertEquals("yes", writer.toString());
+	}
+	@Ignore
+	@Test
+	public void testContainsOperator3() throws PebbleException, IOException {
+		Loader loader = new StringLoader();
+		PebbleEngine pebble = new PebbleEngine(loader);
+
+		String source = "{% if values contains 1 %}yes{% else %}no{% endif %}";
+		PebbleTemplate template = pebble.getTemplate(source);
+		
+		Map<String, Object> context = new HashMap<>();
+		context.put("values", new int[] {1,2});
+		
+		Writer writer = new StringWriter();
+		template.evaluate(writer, context);
+		assertEquals("yes", writer.toString());
+	}
+	@Test
+	public void testContainsOperator4() throws PebbleException, IOException {
+		Loader loader = new StringLoader();
+		PebbleEngine pebble = new PebbleEngine(loader);
+
+		String source = "{% if names contains 'Cobra' %}yes{% else %}no{% endif %}";
+		PebbleTemplate template = pebble.getTemplate(source);
+		
+		Map<String, Object> context = new HashMap<>();
+		context.put("names", Arrays.asList("Bob", "Maria", "John"));
+
+		Writer writer = new StringWriter();
+		template.evaluate(writer, context);
+		assertEquals("no", writer.toString());
+	}
+	@Test
+	public void testContainsOperatorWithAnd() throws PebbleException, IOException {
+		Loader loader = new StringLoader();
+		PebbleEngine pebble = new PebbleEngine(loader);
+
+		String source = "{% if names contains 'Bob' and names contains 'Maria' %}yes{% else %}no{% endif %}";
+		PebbleTemplate template = pebble.getTemplate(source);
+		
+		Map<String, Object> context = new HashMap<>();
+		context.put("names", Arrays.asList("Bob", "Maria", "John"));
+
+		Writer writer = new StringWriter();
+		template.evaluate(writer, context);
+		assertEquals("yes", writer.toString());
+	}
+	@Test
+	public void testContainsOperatorWithOr() throws PebbleException, IOException {
+		Loader loader = new StringLoader();
+		PebbleEngine pebble = new PebbleEngine(loader);
+
+		String source = "{% if names contains 'John' or names contains 'Cobra' %}yes{% else %}no{% endif %}";
+		PebbleTemplate template = pebble.getTemplate(source);
+		
+		Map<String, Object> context = new HashMap<>();
+		context.put("names", Arrays.asList("Bob", "Maria", "John"));
+
+		Writer writer = new StringWriter();
+		template.evaluate(writer, context);
+		assertEquals("yes", writer.toString());
+	}
+	@Test
+	public void testContainsOperatorWithNot() throws PebbleException, IOException {
+		Loader loader = new StringLoader();
+		PebbleEngine pebble = new PebbleEngine(loader);
+
+		String source = "{% if not names contains 'Cobra' %}yes{% else %}no{% endif %}";
+		PebbleTemplate template = pebble.getTemplate(source);
+		
+		Map<String, Object> context = new HashMap<>();
+		context.put("names", Arrays.asList("Bob", "Maria", "John"));
+
+		Writer writer = new StringWriter();
+		template.evaluate(writer, context);
+		assertEquals("yes", writer.toString());
+	}
+
 }

--- a/src/test/java/com/mitchellbosecke/pebble/MapSyntaxTest.java
+++ b/src/test/java/com/mitchellbosecke/pebble/MapSyntaxTest.java
@@ -1,0 +1,446 @@
+/*******************************************************************************
+ * This file is part of Pebble.
+ *
+ * Copyright (c) 2014 by Mitchell Bösecke
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ ******************************************************************************/
+package com.mitchellbosecke.pebble;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.io.Writer;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Test;
+
+import com.mitchellbosecke.pebble.error.ParserException;
+import com.mitchellbosecke.pebble.error.PebbleException;
+import com.mitchellbosecke.pebble.loader.Loader;
+import com.mitchellbosecke.pebble.loader.StringLoader;
+import com.mitchellbosecke.pebble.template.PebbleTemplate;
+
+public class MapSyntaxTest extends AbstractTest {
+	
+	@Test
+	public void testMapSyntax() throws PebbleException, IOException {
+		Loader loader = new StringLoader();
+		PebbleEngine pebble = new PebbleEngine(loader);
+
+		String source = "{{ {} }}";
+		PebbleTemplate template = pebble.getTemplate(source);
+		
+		Writer writer = new StringWriter();
+		template.evaluate(writer, new HashMap<String, Object>());
+		assertEquals("{}", writer.toString());
+	}
+	
+	@Test
+	public void testSimpleMap() throws PebbleException, IOException {
+		Loader loader = new StringLoader();
+		PebbleEngine pebble = new PebbleEngine(loader);
+
+		String source = "{{ {'key':'value'} }}";
+		PebbleTemplate template = pebble.getTemplate(source);
+		
+		Writer writer = new StringWriter();
+		template.evaluate(writer, new HashMap<String, Object>());
+		assertEquals("{key=value}", writer.toString());
+	}
+	
+	@Test
+	public void test2ElementMap() throws PebbleException, IOException {
+		Loader loader = new StringLoader();
+		PebbleEngine pebble = new PebbleEngine(loader);
+
+		String source = "{{ {'key1':'value1','key2':'value2'} }}";
+		PebbleTemplate template = pebble.getTemplate(source);
+		
+		Writer writer = new StringWriter();
+		template.evaluate(writer, new HashMap<String, Object>());
+		assertEquals("{key1=value1, key2=value2}", writer.toString());
+	}
+	@Test
+	public void test2ElementMap2() throws PebbleException, IOException {
+		Loader loader = new StringLoader();
+		PebbleEngine pebble = new PebbleEngine(loader);
+
+		String source = "{{ {'key1' :  'value1'   ,    'key2'      :       'value2' } }}";
+		PebbleTemplate template = pebble.getTemplate(source);
+		
+		Writer writer = new StringWriter();
+		template.evaluate(writer, new HashMap<String, Object>());
+		assertEquals("{key1=value1, key2=value2}", writer.toString());
+	}
+	@Test
+	public void testNElementMap() throws PebbleException, IOException {
+		Loader loader = new StringLoader();
+		PebbleEngine pebble = new PebbleEngine(loader);
+
+		String source = "{{ {'key1':'value1','key2':'value2','key3':'value3','key4':'value4','key5':'value5'} }}";
+		PebbleTemplate template = pebble.getTemplate(source);
+		
+		Writer writer = new StringWriter();
+		template.evaluate(writer, new HashMap<String, Object>());
+		assertEquals("{key1=value1, key2=value2, key5=value5, key3=value3, key4=value4}", writer.toString());
+	}
+	
+	@Test(expected=ParserException.class)
+	public void testIncompleteMapSyntax() throws PebbleException, IOException {
+		Loader loader = new StringLoader();
+		PebbleEngine pebble = new PebbleEngine(loader);
+
+		String source = "{{ {,} }}";
+		PebbleTemplate template = pebble.getTemplate(source);
+		
+		Writer writer = new StringWriter();
+		template.evaluate(writer, new HashMap<String, Object>());
+	}
+	@Test(expected=ParserException.class)
+	public void testIncompleteMapSyntax2() throws PebbleException, IOException {
+		Loader loader = new StringLoader();
+		PebbleEngine pebble = new PebbleEngine(loader);
+
+		String source = "{{ {'key'} }}";
+		PebbleTemplate template = pebble.getTemplate(source);
+		
+		Writer writer = new StringWriter();
+		template.evaluate(writer, new HashMap<String, Object>());
+	}
+	@Test(expected=ParserException.class)
+	public void testIncompleteMapSyntax3() throws PebbleException, IOException {
+		Loader loader = new StringLoader();
+		PebbleEngine pebble = new PebbleEngine(loader);
+
+		String source = "{{ {'key':} }}";
+		PebbleTemplate template = pebble.getTemplate(source);
+		
+		Writer writer = new StringWriter();
+		template.evaluate(writer, new HashMap<String, Object>());
+	}
+	@Test(expected=ParserException.class)
+	public void testIncompleteMapSyntax4() throws PebbleException, IOException {
+		Loader loader = new StringLoader();
+		PebbleEngine pebble = new PebbleEngine(loader);
+
+		String source = "{{ {:'value'} }}";
+		PebbleTemplate template = pebble.getTemplate(source);
+		
+		Writer writer = new StringWriter();
+		template.evaluate(writer, new HashMap<String, Object>());
+	}
+	@Test(expected=ParserException.class)
+	public void testIncompleteMapSyntax5() throws PebbleException, IOException {
+		Loader loader = new StringLoader();
+		PebbleEngine pebble = new PebbleEngine(loader);
+
+		String source = "{{ {'key':'value',} }}";
+		PebbleTemplate template = pebble.getTemplate(source);
+		
+		Writer writer = new StringWriter();
+		template.evaluate(writer, new HashMap<String, Object>());
+	}
+
+	@SuppressWarnings("serial")
+	@Test
+	public void testMapWithExpressions() throws PebbleException, IOException {
+		Loader loader = new StringLoader();
+		PebbleEngine pebble = new PebbleEngine(loader);
+
+		String source = "{{ {1:'one', 'two':2, three:'three', numbers['four']:4} }}";
+		PebbleTemplate template = pebble.getTemplate(source);
+
+		Map<String, Object> context = new HashMap<>();
+		context.put("three", "3");
+		context.put("numbers", new HashMap<String, Object>() {
+			{
+				put("four", "4");
+			}
+		});
+
+		Writer writer = new StringWriter();
+		template.evaluate(writer, context);
+		assertEquals("{1=one, 3=three, 4=4, two=2}", writer.toString());
+	}
+	@SuppressWarnings({"serial","unused"})
+	@Test
+	public void testMapWithComplexExpressions() throws PebbleException, IOException {
+		Loader loader = new StringLoader();
+		PebbleEngine pebble = new PebbleEngine(loader);
+
+		String source = "{{ {'one' + 'plus':'oneplus', 2 - 1:3, three.number:(2+1), 0:numbers['four'][0], numbers ['five'] .value:'five'} }}";
+		PebbleTemplate template = pebble.getTemplate(source);
+
+		Map<String, Object> context = new HashMap<>();
+		context.put("three", new Object() { public Integer number = 3; });
+		context.put("numbers", new HashMap<String, Object>() {
+			{
+				put("four", new String[] {"4"});
+				put("five", new Object() { private String value = "five"; public String getValue() { return this.value; } });
+			}
+		});
+
+		Writer writer = new StringWriter();
+		template.evaluate(writer, context);
+		assertEquals("{0=4, 1=3, 3=3, oneplus=oneplus, five=five}", writer.toString());
+	}
+	
+	@Test
+	public void testSetCommand() throws PebbleException, IOException {
+		Loader loader = new StringLoader();
+		PebbleEngine pebble = new PebbleEngine(loader);
+
+		String source = "{% set map = {'key'+1:'value'+'1'} %}{{ map }}";
+		PebbleTemplate template = pebble.getTemplate(source);
+		
+		Writer writer = new StringWriter();
+		template.evaluate(writer, new HashMap<String, Object>());
+		assertEquals("{key1=value1}", writer.toString());
+	}
+	
+	
+	// this tests use string 'contains' semantics because entry order can't be trusted
+	@Test
+	public void testForTag() throws PebbleException, IOException {
+		Loader loader = new StringLoader();
+		PebbleEngine pebble = new PebbleEngine(loader);
+
+		String source = "{% set names = {'Bob':'Marley','Maria':'Callas','John':'Cobra'} %}{% for name in names %}{{ name.key + '-' + name.value }}{% endfor %}";
+		PebbleTemplate template = pebble.getTemplate(source);
+		
+		Writer writer = new StringWriter();
+		template.evaluate(writer, new HashMap<String, Object>());
+		String result = writer.toString();
+		assertTrue(result.indexOf("Bob-Marley") > -1);
+		assertTrue(result.indexOf("Maria-Callas") > -1);
+		assertTrue(result.indexOf("John-Cobra") > -1);
+	}
+	@Test
+	public void testForTag2() throws PebbleException, IOException {
+		Loader loader = new StringLoader();
+		PebbleEngine pebble = new PebbleEngine(loader);
+
+		String source = "{% for name in {'Bob':'Marley','Maria':'Callas','John':'Cobra'} %}{{ name.key + '-' + name.value }}{% endfor %}";
+		PebbleTemplate template = pebble.getTemplate(source);
+		
+		Writer writer = new StringWriter();
+		template.evaluate(writer, new HashMap<String, Object>());
+		String result = writer.toString();
+		assertTrue(result.indexOf("Bob-Marley") > -1);
+		assertTrue(result.indexOf("Maria-Callas") > -1);
+		assertTrue(result.indexOf("John-Cobra") > -1);
+	}
+	@Test
+	public void testForElseTag() throws PebbleException, IOException {
+		Loader loader = new StringLoader();
+		PebbleEngine pebble = new PebbleEngine(loader);
+
+		String source = "{% for name in {} %}{{ name }}{% else %}{{ 'no name' }}{% endfor %}";
+		PebbleTemplate template = pebble.getTemplate(source);
+		
+		Writer writer = new StringWriter();
+		template.evaluate(writer, new HashMap<String, Object>());
+		assertEquals("no name", writer.toString());
+	}
+	
+	@Test
+	public void testIfTag() throws PebbleException, IOException {
+		Loader loader = new StringLoader();
+		PebbleEngine pebble = new PebbleEngine(loader);
+
+		String source = "{% if {'Bob':'Marley','Maria':'Callas','John':'Cobra'} is null %}{{ 'it is' }}{% else %}{{ 'it is not' }}{% endif %}";
+		PebbleTemplate template = pebble.getTemplate(source);
+		
+		Writer writer = new StringWriter();
+		template.evaluate(writer, new HashMap<String, Object>());
+		assertEquals("it is not", writer.toString());
+	}
+	
+	@Test
+	public void testMacroTag() throws PebbleException, IOException {
+		Loader loader = new StringLoader();
+		PebbleEngine pebble = new PebbleEngine(loader);
+
+		String source = "{% macro print(name) %}{{ name }}{% endmacro %}{{ print({'Bob':'Marley'}) }}";
+		PebbleTemplate template = pebble.getTemplate(source);
+		
+		Writer writer = new StringWriter();
+		template.evaluate(writer, new HashMap<String, Object>());
+		assertEquals("{Bob=Marley}", writer.toString());
+	}
+	@Test
+	public void testMacroTagNamedArguments() throws PebbleException, IOException {
+		Loader loader = new StringLoader();
+		PebbleEngine pebble = new PebbleEngine(loader);
+
+		String source = "{% macro print(name) %}{{ name }}{% endmacro %}{{ print(name={'Bob':'Marley'}) }}";
+		PebbleTemplate template = pebble.getTemplate(source);
+		
+		Writer writer = new StringWriter();
+		template.evaluate(writer, new HashMap<String, Object>());
+		assertEquals("{Bob=Marley}", writer.toString());
+	}
+
+	// no operator overloading for maps
+	@Test(expected=RuntimeException.class)
+	public void testAdditionOverloading() throws PebbleException, IOException {
+		Loader loader = new StringLoader();
+		PebbleEngine pebble = new PebbleEngine(loader);
+
+		String source = "{% set map = {'Bob':'Marley'} + 1 %}{{ map }}";
+		PebbleTemplate template = pebble.getTemplate(source);
+		
+		Writer writer = new StringWriter();
+		template.evaluate(writer, new HashMap<String, Object>());
+	}
+	@Test(expected=RuntimeException.class)
+	public void testSubtractionOverloading() throws PebbleException, IOException {
+		Loader loader = new StringLoader();
+		PebbleEngine pebble = new PebbleEngine(loader);
+
+		String source = "{% set map = {'Bob':'Marley'} - 1 %}{{ map }}";
+		PebbleTemplate template = pebble.getTemplate(source);
+		
+		Writer writer = new StringWriter();
+		template.evaluate(writer, new HashMap<String, Object>());
+	}
+	
+	@Test
+	public void testEmptyTest() throws PebbleException, IOException {
+		Loader loader = new StringLoader();
+		PebbleEngine pebble = new PebbleEngine(loader);
+
+		String source = "{% if {'John':'Cobra'} is empty %}{{ 'true' }}{% else %}{{ 'false' }}{% endif %}";
+		PebbleTemplate template = pebble.getTemplate(source);
+		
+		Writer writer = new StringWriter();
+		template.evaluate(writer, new HashMap<String, Object>());
+		assertEquals("false", writer.toString());
+	}
+	@Test
+	public void testEmptyTest2() throws PebbleException, IOException {
+		Loader loader = new StringLoader();
+		PebbleEngine pebble = new PebbleEngine(loader);
+
+		String source = "{% if {} is empty %}{{ 'true' }}{% else %}{{ 'false' }}{% endif %}";
+		PebbleTemplate template = pebble.getTemplate(source);
+		
+		Writer writer = new StringWriter();
+		template.evaluate(writer, new HashMap<String, Object>());
+		assertEquals("true", writer.toString());
+	}
+	
+	@Test
+	public void testIterableTest() throws PebbleException, IOException {
+		Loader loader = new StringLoader();
+		PebbleEngine pebble = new PebbleEngine(loader);
+
+		String source = "{% if {} is iterable %}true{% else %}false{% endif %}";
+		PebbleTemplate template = pebble.getTemplate(source);
+		
+		Writer writer = new StringWriter();
+		template.evaluate(writer, new HashMap<String, Object>());
+		assertEquals("false", writer.toString());
+	}
+	
+	@Test
+	public void testMapTest() throws PebbleException, IOException {
+		Loader loader = new StringLoader();
+		PebbleEngine pebble = new PebbleEngine(loader);
+
+		String source = "{% if {} is map %}true{% else %}false{% endif %}";
+		PebbleTemplate template = pebble.getTemplate(source);
+		
+		Writer writer = new StringWriter();
+		template.evaluate(writer, new HashMap<String, Object>());
+		assertEquals("true", writer.toString());
+	}
+	
+	@Test
+	public void testContainsOperator() throws PebbleException, IOException {
+		Loader loader = new StringLoader();
+		PebbleEngine pebble = new PebbleEngine(loader);
+
+		String source = "{% if {'Bob':'Marley','Maria':'Callas','John':'Cobra'} contains 'Maria' %}true{% endif %}";
+		PebbleTemplate template = pebble.getTemplate(source);
+		
+		Writer writer = new StringWriter();
+		template.evaluate(writer, new HashMap<String, Object>());
+		assertEquals("true", writer.toString());
+	}
+	@Test
+	public void testContainsOperator2() throws PebbleException, IOException {
+		Loader loader = new StringLoader();
+		PebbleEngine pebble = new PebbleEngine(loader);
+
+		String source = "{% if not {'Bob':'Marley','Maria':'Callas','John':'Cobra'} contains 'Freddie' %}true{% else %}false{% endif %}";
+		PebbleTemplate template = pebble.getTemplate(source);
+		
+		Writer writer = new StringWriter();
+		template.evaluate(writer, new HashMap<String, Object>());
+		assertEquals("true", writer.toString());
+	}
+	@Test
+	public void testContainsOperator3() throws PebbleException, IOException {
+		Loader loader = new StringLoader();
+		PebbleEngine pebble = new PebbleEngine(loader);
+
+		String source = "{% if {'Bob':'Marley','Maria':'Callas','John':'Cobra'} contains 'John' and not {'Freddie':'Mercury'} contains 'Bob' %}true{% else %}false{% endif %}";
+		PebbleTemplate template = pebble.getTemplate(source);
+		
+		Writer writer = new StringWriter();
+		template.evaluate(writer, new HashMap<String, Object>());
+		assertEquals("true", writer.toString());
+	}
+	
+	@Test
+	public void testNestedMaps() throws PebbleException, IOException {
+		Loader loader = new StringLoader();
+		PebbleEngine pebble = new PebbleEngine(loader);
+
+		String source = "{{ { 1 : {}, 2 : { 1 : 1 }, { 3 : 3} : 3, 4 : { 4 : { 4 : 4 } } } }}";
+		PebbleTemplate template = pebble.getTemplate(source);
+		
+		Writer writer = new StringWriter();
+		template.evaluate(writer, new HashMap<String, Object>());
+		assertEquals("{{3=3}=3, 1={}, 2={1=1}, 4={4={4=4}}}", writer.toString());
+	}
+	
+	@Test
+	public void testNestedArrayInMap() throws PebbleException, IOException {
+		Loader loader = new StringLoader();
+		PebbleEngine pebble = new PebbleEngine(loader);
+
+		String source = "{{ {'array':[]} }}";
+		PebbleTemplate template = pebble.getTemplate(source);
+		
+		Writer writer = new StringWriter();
+		template.evaluate(writer, new HashMap<String, Object>());
+		assertEquals("{array=[]}", writer.toString());
+	}
+	
+	
+	
+	
+	// brace syntax regression tests
+	
+	@Test
+	public void testBraceSyntax() throws PebbleException, IOException {
+		Loader loader = new StringLoader();
+		PebbleEngine pebble = new PebbleEngine(loader);
+		pebble.setStrictVariables(false);
+
+		String source = "{% set var = true %}{{ 'hi' }}{# comment #}";
+		PebbleTemplate template = pebble.getTemplate(source);
+
+		Writer writer = new StringWriter();
+		template.evaluate(writer);
+		assertEquals("hi", writer.toString());
+	}
+
+}


### PR DESCRIPTION
Syntax for instantiating arrays/maps as context variables.

There are a few //FIXME with design decisions that I didn't feel to tackle. Most troubling ones have to do with primitive arrays.

Noteworthy:
- forgot to add tests for MapTest
- forgot to format sources with your style. Sorry!