### PR TITLE
Add missing break statement in EscapeFilter

### DIFF
--- a/src/main/java/com/mitchellbosecke/pebble/extension/escaper/EscapeFilter.java
+++ b/src/main/java/com/mitchellbosecke/pebble/extension/escaper/EscapeFilter.java
@@ -56,6 +56,7 @@ public class EscapeFilter implements Filter {
             break;
         case "url_param":
             input = Escape.uriParam(input);
+            break;
         default:
             throw new RuntimeException("Unknown escaping strategy");
 


### PR DESCRIPTION
This missing break statement means it is impossible to use the escape strategy `url_param`, as it is treated as urecognized. This PR fixes this.