### PR TITLE
Fix for Pebble issue #76

### DIFF
--- a/src/main/java/com/mitchellbosecke/pebble/error/RootAttributeNotFoundException.java
+++ b/src/main/java/com/mitchellbosecke/pebble/error/RootAttributeNotFoundException.java
@@ -1,0 +1,22 @@
+/*******************************************************************************
+ * This file is part of Pebble.
+ * 
+ * Copyright (c) 2014 by Mitchell Bösecke
+ * 
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ ******************************************************************************/
+package com.mitchellbosecke.pebble.error;
+
+public class RootAttributeNotFoundException extends AttributeNotFoundException {
+
+    /**
+	 * 
+	 */
+    private static final long serialVersionUID = 3863732457312917327L;
+
+    public RootAttributeNotFoundException(Throwable cause, String message) {
+        super(cause, message);
+    }
+
+}

--- a/src/main/java/com/mitchellbosecke/pebble/node/expression/GetAttributeExpression.java
+++ b/src/main/java/com/mitchellbosecke/pebble/node/expression/GetAttributeExpression.java
@@ -19,6 +19,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import com.mitchellbosecke.pebble.error.AttributeNotFoundException;
 import com.mitchellbosecke.pebble.error.PebbleException;
+import com.mitchellbosecke.pebble.error.RootAttributeNotFoundException;
 import com.mitchellbosecke.pebble.extension.NodeVisitor;
 import com.mitchellbosecke.pebble.node.ArgumentsNode;
 import com.mitchellbosecke.pebble.node.PositionalArgumentNode;
@@ -131,11 +132,20 @@ public class GetAttributeExpression implements Expression<Object> {
             }
             result = invokeMember(object, member, argumentValues);
         } else if (context.isStrictVariables()) {
-            throw new AttributeNotFoundException(
+        	if (object == null) {
+        		final String rootPropertyName = ((ContextVariableExpression)node).getName();
+        		throw new RootAttributeNotFoundException(
+                        null,
+                        String.format(
+                                "Root attribute [%s] does not exist or can not be accessed and strict variables is set to true.",
+                                rootPropertyName));
+        	} else {
+        		throw new AttributeNotFoundException(
                     null,
                     String.format(
                             "Attribute [%s] of [%s] does not exist or can not be accessed and strict variables is set to true.",
                             attributeName, object.getClass().getName()));
+        	}
         }
         return result;
 

--- a/src/test/java/com/mitchellbosecke/pebble/ErrorReportingTest.java
+++ b/src/test/java/com/mitchellbosecke/pebble/ErrorReportingTest.java
@@ -17,6 +17,7 @@ import org.junit.Test;
 
 import com.mitchellbosecke.pebble.error.ParserException;
 import com.mitchellbosecke.pebble.error.PebbleException;
+import com.mitchellbosecke.pebble.error.RootAttributeNotFoundException;
 import com.mitchellbosecke.pebble.loader.Loader;
 import com.mitchellbosecke.pebble.loader.StringLoader;
 import com.mitchellbosecke.pebble.template.PebbleTemplate;
@@ -61,6 +62,23 @@ public class ErrorReportingTest extends AbstractTest {
             String message = ex.getMessage();
             assertEquals(":8)", message.substring(message.length() - 3, message.length()));
             throw ex;
+        }
+    }
+    
+    @Test(expected = RootAttributeNotFoundException.class)
+    public void testMissingRootPropertyInStrictMode() throws PebbleException, IOException {
+        try {
+        	pebble.setStrictVariables(true);
+            PebbleTemplate template = pebble.getTemplate("template.errorReportingMissingRootProperty.peb");
+            template.evaluate(new StringWriter());
+        } catch (PebbleException ex) {
+            String message = ex.getMessage();
+            assertEquals(message, "Root attribute [root] does not exist or can not be accessed and strict variables is set to true. (?:?)");
+            throw ex;
+        }
+        finally
+        {
+        	pebble.setStrictVariables(false);
         }
     }
 

--- a/src/test/java/com/mitchellbosecke/pebble/GetAttributeTest.java
+++ b/src/test/java/com/mitchellbosecke/pebble/GetAttributeTest.java
@@ -22,6 +22,7 @@ import org.junit.Test;
 
 import com.mitchellbosecke.pebble.error.AttributeNotFoundException;
 import com.mitchellbosecke.pebble.error.PebbleException;
+import com.mitchellbosecke.pebble.error.RootAttributeNotFoundException;
 import com.mitchellbosecke.pebble.loader.Loader;
 import com.mitchellbosecke.pebble.loader.StringLoader;
 import com.mitchellbosecke.pebble.template.PebbleTemplate;
@@ -250,7 +251,7 @@ public class GetAttributeTest extends AbstractTest {
 		assertEquals("hello Steve. My name is Steve.", writer.toString());
 	}
 
-	@Test(expected = NullPointerException.class)
+	@Test(expected = RootAttributeNotFoundException.class)
 	public void testAttributeOfNullObjectWithStrictVariables() throws PebbleException, IOException {
 		Loader stringLoader = new StringLoader();
 		PebbleEngine pebble = new PebbleEngine(stringLoader);

--- a/src/test/resources/templates/template.errorReportingMissingRootProperty.peb
+++ b/src/test/resources/templates/template.errorReportingMissingRootProperty.peb
@@ -1,0 +1,2 @@
+{# used by ErrorReportingTest.testMissingRootPropertyInStrictMode #}
+{{root.foo}}


### PR DESCRIPTION
I created RootAttributeNotFoundException as a subclasss of AttributeNotFoundException so that it is possible to distinguish the difference if need be. I also changed an existing test that expected NPE, as I feel this is a very generic exception that can hide other issues.