### PR TITLE
Add "rsort" filter and fix primitive array subscripting.

### DIFF
--- a/src/main/java/com/mitchellbosecke/pebble/extension/core/CoreExtension.java
+++ b/src/main/java/com/mitchellbosecke/pebble/extension/core/CoreExtension.java
@@ -126,6 +126,7 @@ public class CoreExtension extends AbstractExtension {
         filters.put("numberformat", new NumberFormatFilter());
         filters.put("slice", new SliceFilter());
         filters.put("sort", new SortFilter());
+        filters.put("rsort", new RsortFilter());
         filters.put("title", new TitleFilter());
         filters.put("trim", new TrimFilter());
         filters.put("upper", new UpperFilter());

--- a/src/main/java/com/mitchellbosecke/pebble/extension/core/RsortFilter.java
+++ b/src/main/java/com/mitchellbosecke/pebble/extension/core/RsortFilter.java
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * This file is part of Pebble.
+ * 
+ * Copyright (c) 2014 by Mitchell Bösecke
+ * 
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ ******************************************************************************/
+package com.mitchellbosecke.pebble.extension.core;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import com.mitchellbosecke.pebble.extension.Filter;
+
+/**
+ * Sort list items in the reverse order
+ * 
+ * @author Barakat Soror
+ *
+ */
+public class RsortFilter implements Filter {
+
+    @Override
+    public List<String> getArgumentNames() {
+        return null;
+    }
+
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    @Override
+    public List<Comparable> apply(Object input, Map<String, Object> args) {
+        if (input == null) {
+            return null;
+        }
+        List<Comparable> collection = (List<Comparable>) input;
+        Collections.sort(collection, Collections.reverseOrder());
+        return collection;
+    }
+
+}

--- a/src/main/java/com/mitchellbosecke/pebble/node/expression/GetAttributeExpression.java
+++ b/src/main/java/com/mitchellbosecke/pebble/node/expression/GetAttributeExpression.java
@@ -13,6 +13,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Member;
 import java.lang.reflect.Method;
+import java.lang.reflect.Array;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -89,10 +90,9 @@ public class GetAttributeExpression implements Expression<Object> {
                 try {
 
                     // then we check arrays
-                    if (object instanceof Object[]) {
-                        Integer key = Integer.valueOf(attributeName);
-                        Object[] arr = ((Object[]) object);
-                        return arr[key];
+                    if (object.getClass().isArray()) {
+                        int index = Integer.parseInt(attributeName);
+                        return Array.get(object, index);
                     }
 
                     // then lists

--- a/src/test/java/com/mitchellbosecke/pebble/CoreFiltersTest.java
+++ b/src/test/java/com/mitchellbosecke/pebble/CoreFiltersTest.java
@@ -769,9 +769,7 @@ public class CoreFiltersTest extends AbstractTest {
         template.evaluate(writer, context);
         assertEquals("Bob", writer.toString());
     }
-    //FIXME primitive values are not printed to output
-    // maybe test with contains test?
-    @Ignore
+
     @Test
     public void testSliceWithPrimitivesArray() throws PebbleException, IOException {
         Loader loader = new StringLoader();

--- a/src/test/java/com/mitchellbosecke/pebble/CoreFiltersTest.java
+++ b/src/test/java/com/mitchellbosecke/pebble/CoreFiltersTest.java
@@ -354,6 +354,27 @@ public class CoreFiltersTest extends AbstractTest {
     }
 
     @Test
+    public void testRsortFilter() throws PebbleException, IOException {
+        Loader loader = new StringLoader();
+        PebbleEngine pebble = new PebbleEngine(loader);
+
+        PebbleTemplate template = pebble.getTemplate("{% for word in words|rsort %}{{ word }} {% endfor %}");
+        List<String> words = new ArrayList<>();
+        words.add("zebra");
+        words.add("apple");
+        words.add(" cat");
+        words.add("123");
+        words.add("Apple");
+        words.add("cat");
+
+        Map<String, Object> context = new HashMap<>();
+        context.put("words", words);
+        Writer writer = new StringWriter();
+        template.evaluate(writer, context);
+        assertEquals("zebra cat apple Apple 123  cat ", writer.toString());
+    }
+
+    @Test
     public void testTitle() throws PebbleException, IOException {
         Loader loader = new StringLoader();
         PebbleEngine pebble = new PebbleEngine(loader);


### PR DESCRIPTION
Add "rsort" filter to sort list items in the reverse order.

Update: I've noted the comment in the on the ignored test `CoreFiltersTest#testSliceWithPrimitivesArray`. The issue is located in `GetAttributeExpression#evaluate`. The initial implementation handles only array of references, in the second commit I modified it to handle arrays of any type and removed `@Ignore` so now all tests pass.