### PR TITLE
Add support for parsing template in parallel.

### DIFF
--- a/src/main/java/com/mitchellbosecke/pebble/PebbleEngine.java
+++ b/src/main/java/com/mitchellbosecke/pebble/PebbleEngine.java
@@ -19,7 +19,6 @@ import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Semaphore;
 
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
@@ -28,13 +27,13 @@ import com.mitchellbosecke.pebble.error.PebbleException;
 import com.mitchellbosecke.pebble.extension.Extension;
 import com.mitchellbosecke.pebble.extension.Filter;
 import com.mitchellbosecke.pebble.extension.Function;
-import com.mitchellbosecke.pebble.extension.NodeVisitor;
+import com.mitchellbosecke.pebble.extension.NodeVisitorFactory;
 import com.mitchellbosecke.pebble.extension.Test;
 import com.mitchellbosecke.pebble.extension.core.CoreExtension;
 import com.mitchellbosecke.pebble.extension.escaper.EscaperExtension;
 import com.mitchellbosecke.pebble.extension.i18n.I18nExtension;
-import com.mitchellbosecke.pebble.lexer.Lexer;
 import com.mitchellbosecke.pebble.lexer.LexerImpl;
+import com.mitchellbosecke.pebble.lexer.Syntax;
 import com.mitchellbosecke.pebble.lexer.TokenStream;
 import com.mitchellbosecke.pebble.loader.ClasspathLoader;
 import com.mitchellbosecke.pebble.loader.DelegatingLoader;
@@ -64,9 +63,7 @@ public class PebbleEngine {
      */
     private Loader<?> loader;
 
-    private final Parser parser;
-
-    private final Lexer lexer;
+    private final Syntax syntax;
 
     /*
      * User Editable Settings
@@ -104,13 +101,7 @@ public class PebbleEngine {
 
     private Map<String, Function> functions = new HashMap<>();
 
-    private List<NodeVisitor> nodeVisitors = new ArrayList<>();
-
-    /**
-     * compilationMutex ensures that only one template is being compiled at a
-     * time. Only concurrent evaluation is supported at this time.
-     */
-    private final Semaphore compilationMutex = new Semaphore(1, true);
+    private List<NodeVisitorFactory> nodeVisitors = new ArrayList<>();
 
     public PebbleEngine() {
         this(null);
@@ -148,8 +139,41 @@ public class PebbleEngine {
      *            The template loader for this engine
      * @param extensions
      *            The extensions which should be loaded.
+     * @param syntax
+     *            the syntax to use for parsing the templates.
+     */
+    public PebbleEngine(Loader<?> loader, Syntax syntax, Extension... extensions) {
+        this(loader, syntax, Arrays.asList(extensions));
+    }
+
+    /**
+     * Constructor for the Pebble Engine given an instantiated Loader. This
+     * method does only load those extensions listed here.
+     *
+     * @param loader
+     *            The template loader for this engine
+     * @param extensions
+     *            The extensions which should be loaded.
+     * @param syntax
+     *            the syntax to use for parsing the templates.
      */
     public PebbleEngine(Loader<?> loader, Collection<? extends Extension> extensions) {
+        this(loader, new Syntax.Builder().build(), extensions);
+    }
+
+    /**
+     * Constructor for the Pebble Engine given an instantiated Loader. This
+     * method does only load those extensions listed here.
+     *
+     * @param loader
+     *            The template loader for this engine
+     * @param syntax
+     *            the syntax to use for parsing the templates.
+     * @param extensions
+     *            The extensions which should be loaded.
+     */
+    public PebbleEngine(Loader<?> loader, Syntax syntax, Collection<? extends Extension> extensions) {
+        this.syntax = syntax;
 
         // set up a default loader if necessary
         if (loader == null) {
@@ -163,8 +187,6 @@ public class PebbleEngine {
         templateCache = CacheBuilder.newBuilder().maximumSize(200).build();
 
         this.loader = loader;
-        lexer = new LexerImpl(this);
-        parser = new ParserImpl(this);
 
         // register default extensions
         for (Extension extension : extensions) {
@@ -208,25 +230,17 @@ public class PebbleEngine {
 
                 public PebbleTemplateImpl call() throws Exception {
 
-                    compilationMutex.acquire();
+                    LexerImpl lexer = new LexerImpl(self);
+                    Reader templateReader = self.retrieveReaderFromLoader(self.loader, cacheKey);
+                    TokenStream tokenStream = lexer.tokenize(templateReader, templateName);
 
-                    PebbleTemplateImpl instance = null;
-                    RootNode root = null;
+                    Parser parser = new ParserImpl(self);
+                    RootNode root = parser.parse(tokenStream);
 
-                    try {
-                        Reader templateReader = self.retrieveReaderFromLoader(self.loader, cacheKey);
-                        TokenStream tokenStream = lexer.tokenize(templateReader, templateName);
-                        root = parser.parse(tokenStream);
+                    PebbleTemplateImpl instance = new PebbleTemplateImpl(self, root, templateName);
 
-                        instance = new PebbleTemplateImpl(self, root, templateName);
-
-                        for (NodeVisitor visitor : nodeVisitors) {
-                            visitor.setTemplate(instance);
-                            visitor.visit(root);
-                        }
-
-                    } finally {
-                        compilationMutex.release();
+                    for (NodeVisitorFactory visitorFactory : nodeVisitors) {
+                        visitorFactory.createVisitor(instance).visit(root);
                     }
 
                     return instance;
@@ -282,14 +296,6 @@ public class PebbleEngine {
 
     public Loader<?> getLoader() {
         return loader;
-    }
-
-    public Parser getParser() {
-        return parser;
-    }
-
-    public Lexer getLexer() {
-        return lexer;
     }
 
     public void addExtension(Extension extension) {
@@ -348,7 +354,7 @@ public class PebbleEngine {
         }
 
         // node visitors
-        List<NodeVisitor> nodeVisitors = extension.getNodeVisitors();
+        List<NodeVisitorFactory> nodeVisitors = extension.getNodeVisitors();
         if (nodeVisitors != null) {
             this.nodeVisitors.addAll(nodeVisitors);
         }
@@ -388,7 +394,7 @@ public class PebbleEngine {
         return this.globalVariables;
     }
 
-    public List<NodeVisitor> getNodeVisitors() {
+    public List<NodeVisitorFactory> getNodeVisitors() {
         return this.nodeVisitors;
     }
 
@@ -456,4 +462,14 @@ public class PebbleEngine {
     public void setExecutorService(ExecutorService executorService) {
         this.executorService = executorService;
     }
+
+    /**
+     * Returns the syntax which is used by this PebbleEngine.
+     *
+     * @return the syntax used by the PebbleEngine.
+     */
+    public Syntax getSyntax() {
+        return this.syntax;
+    }
+
 }

--- a/src/main/java/com/mitchellbosecke/pebble/extension/AbstractExtension.java
+++ b/src/main/java/com/mitchellbosecke/pebble/extension/AbstractExtension.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of Pebble.
- * 
+ *
  * Copyright (c) 2014 by Mitchell Bösecke
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  ******************************************************************************/
@@ -53,7 +53,7 @@ public abstract class AbstractExtension implements Extension {
     }
 
     @Override
-    public List<NodeVisitor> getNodeVisitors() {
+    public List<NodeVisitorFactory> getNodeVisitors() {
         return null;
     }
 }

--- a/src/main/java/com/mitchellbosecke/pebble/extension/AbstractNodeVisitor.java
+++ b/src/main/java/com/mitchellbosecke/pebble/extension/AbstractNodeVisitor.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of Pebble.
- * 
+ *
  * Copyright (c) 2014 by Mitchell Bösecke
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  ******************************************************************************/
@@ -34,15 +34,15 @@ import com.mitchellbosecke.pebble.utils.Pair;
 /**
  * A base node visitor that can be extended for the sake of using it's
  * navigational abilities.
- * 
+ *
  * @author Mitchell
- * 
+ *
  */
 public class AbstractNodeVisitor implements NodeVisitor {
 
-    protected PebbleTemplateImpl template;
+    private final PebbleTemplateImpl template;
 
-    public void setTemplate(PebbleTemplateImpl template) {
+    public AbstractNodeVisitor(PebbleTemplateImpl template) {
         this.template = template;
     }
 
@@ -169,6 +169,10 @@ public class AbstractNodeVisitor implements NodeVisitor {
     @Override
     public void visit(TextNode node) {
 
+    }
+
+    protected PebbleTemplateImpl getTemplate() {
+        return this.template;
     }
 
 }

--- a/src/main/java/com/mitchellbosecke/pebble/extension/Extension.java
+++ b/src/main/java/com/mitchellbosecke/pebble/extension/Extension.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of Pebble.
- * 
+ *
  * Copyright (c) 2014 by Mitchell Bösecke
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  ******************************************************************************/
@@ -19,60 +19,60 @@ public interface Extension {
 
     /**
      * Use this method to provide custom filters.
-     * 
+     *
      * @return A list of filters. It is okay to return null.
      */
     Map<String, Filter> getFilters();
 
     /**
      * Use this method to provide custom tests.
-     * 
+     *
      * @return A list of tests. It is okay to return null.
      */
     Map<String, Test> getTests();
 
     /**
      * Use this method to provide custom functions.
-     * 
+     *
      * @return A list of functions. It is okay to return null.
      */
     Map<String, Function> getFunctions();
 
     /**
      * Use this method to provide custom tags.
-     * 
+     *
      * A TokenParser is used to parse a stream of tokens into Nodes which are
      * then responsible for compiling themselves into Java.
-     * 
+     *
      * @return A list of TokenParsers. It is okay to return null.
      */
     List<TokenParser> getTokenParsers();
 
     /**
      * Use this method to provide custom binary operators.
-     * 
+     *
      * @return A list of Operators. It is okay to return null;
      */
     List<BinaryOperator> getBinaryOperators();
 
     /**
      * Use this method to provide custom unary operators.
-     * 
+     *
      * @return A list of Operators. It is okay to return null;
      */
     List<UnaryOperator> getUnaryOperators();
 
     /**
      * Use this method to provide variables available to all templates
-     * 
+     *
      * @return Map of global variables available to all templates
      */
     Map<String, Object> getGlobalVariables();
 
     /**
      * Node visitors will travel the AST tree during the compilation phase.
-     * 
+     *
      * @return a list of node visitors
      */
-    List<NodeVisitor> getNodeVisitors();
+    List<NodeVisitorFactory> getNodeVisitors();
 }

--- a/src/main/java/com/mitchellbosecke/pebble/extension/NodeVisitor.java
+++ b/src/main/java/com/mitchellbosecke/pebble/extension/NodeVisitor.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of Pebble.
- * 
+ *
  * Copyright (c) 2014 by Mitchell Bösecke
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  ******************************************************************************/
@@ -27,27 +27,27 @@ import com.mitchellbosecke.pebble.node.PrintNode;
 import com.mitchellbosecke.pebble.node.RootNode;
 import com.mitchellbosecke.pebble.node.SetNode;
 import com.mitchellbosecke.pebble.node.TextNode;
-import com.mitchellbosecke.pebble.template.PebbleTemplateImpl;
 
 /**
  * Will visit all the nodes of the AST provided by the parser. The NodeVisitor
  * is responsible for the navigating the tree, it can extend AbstractNodeVisitor
  * for help with this.
- * 
+ *
  * A NodeVisitor can still use method overloading to visit expressions (it's
  * just not required).
- * 
+ *
+ * <p>
+ * The implementor does not need to make sure that the implementation is thread-safe.
+ *
  * @author Mitchell
- * 
+ *
  */
 public interface NodeVisitor {
-
-    void setTemplate(PebbleTemplateImpl template);
 
     /**
      * Default method invoked with unknown nodes such as nodes provided by user
      * extensions.
-     * 
+     *
      * @param node Node to visit
      */
     void visit(Node node);

--- a/src/main/java/com/mitchellbosecke/pebble/extension/NodeVisitorFactory.java
+++ b/src/main/java/com/mitchellbosecke/pebble/extension/NodeVisitorFactory.java
@@ -1,0 +1,34 @@
+package com.mitchellbosecke.pebble.extension;
+
+import com.mitchellbosecke.pebble.template.PebbleTemplate;
+
+/**
+ * The node visitor factory creates {@link NodeVisitor}s.
+ *
+ * <p>
+ * {@link Extension} can provide own implementation to provide their own
+ * {@link NodeVisitor}s.
+ *
+ * @author Thomas Hunziker
+ *
+ */
+public interface NodeVisitorFactory {
+
+    /**
+     * This method creates a new instance of a {@link NodeVisitor}.
+     *
+     * <p>
+     * The method is called whenever a visitor is applied to a
+     * {@link PebbleTemplate}.
+     *
+     * <p>
+     * The method needs to be thread-safe. However the {@link NodeVisitor}
+     * itself does not need to be thread-safe.
+     *
+     * @param template
+     *            the template for which a visitor should be created for.
+     * @return the visitor.
+     */
+    public NodeVisitor createVisitor(PebbleTemplate template);
+
+}

--- a/src/main/java/com/mitchellbosecke/pebble/extension/core/CoreExtension.java
+++ b/src/main/java/com/mitchellbosecke/pebble/extension/core/CoreExtension.java
@@ -16,7 +16,7 @@ import java.util.Map;
 import com.mitchellbosecke.pebble.extension.AbstractExtension;
 import com.mitchellbosecke.pebble.extension.Filter;
 import com.mitchellbosecke.pebble.extension.Function;
-import com.mitchellbosecke.pebble.extension.NodeVisitor;
+import com.mitchellbosecke.pebble.extension.NodeVisitorFactory;
 import com.mitchellbosecke.pebble.extension.Test;
 import com.mitchellbosecke.pebble.node.expression.AddExpression;
 import com.mitchellbosecke.pebble.node.expression.AndExpression;
@@ -169,9 +169,9 @@ public class CoreExtension extends AbstractExtension {
         return null;
     }
 
-    public List<NodeVisitor> getNodeVisitors() {
-        List<NodeVisitor> visitors = new ArrayList<>();
-        visitors.add(new MacroAndBlockRegistrantNodeVisitor());
+    public List<NodeVisitorFactory> getNodeVisitors() {
+        List<NodeVisitorFactory> visitors = new ArrayList<>();
+        visitors.add(new MacroAndBlockRegistrantNodeVisitorFactory());
         return visitors;
     }
 

--- a/src/main/java/com/mitchellbosecke/pebble/extension/core/MacroAndBlockRegistrantNodeVisitor.java
+++ b/src/main/java/com/mitchellbosecke/pebble/extension/core/MacroAndBlockRegistrantNodeVisitor.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of Pebble.
- * 
+ *
  * Copyright (c) 2014 by Mitchell Bösecke
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  ******************************************************************************/
@@ -12,19 +12,24 @@ import com.mitchellbosecke.pebble.error.PebbleException;
 import com.mitchellbosecke.pebble.extension.AbstractNodeVisitor;
 import com.mitchellbosecke.pebble.node.BlockNode;
 import com.mitchellbosecke.pebble.node.MacroNode;
+import com.mitchellbosecke.pebble.template.PebbleTemplateImpl;
 
 public class MacroAndBlockRegistrantNodeVisitor extends AbstractNodeVisitor {
 
+    public MacroAndBlockRegistrantNodeVisitor(PebbleTemplateImpl template) {
+        super(template);
+    }
+
     @Override
     public void visit(BlockNode node) {
-        template.registerBlock(node.getBlock());
+        this.getTemplate().registerBlock(node.getBlock());
         super.visit(node);
     }
 
     @Override
     public void visit(MacroNode node) {
         try {
-            template.registerMacro(node.getMacro());
+            this.getTemplate().registerMacro(node.getMacro());
         } catch (PebbleException e) {
             throw new RuntimeException(e);
         }

--- a/src/main/java/com/mitchellbosecke/pebble/extension/core/MacroAndBlockRegistrantNodeVisitorFactory.java
+++ b/src/main/java/com/mitchellbosecke/pebble/extension/core/MacroAndBlockRegistrantNodeVisitorFactory.java
@@ -1,0 +1,22 @@
+package com.mitchellbosecke.pebble.extension.core;
+
+import com.mitchellbosecke.pebble.extension.NodeVisitor;
+import com.mitchellbosecke.pebble.extension.NodeVisitorFactory;
+import com.mitchellbosecke.pebble.template.PebbleTemplate;
+import com.mitchellbosecke.pebble.template.PebbleTemplateImpl;
+
+/**
+ * Implementation of {@link NodeVisitorFactory} to handle
+ * {@link MacroAndBlockRegistrantNodeVisitor}.
+ *
+ * @author hunziker
+ *
+ */
+public class MacroAndBlockRegistrantNodeVisitorFactory implements NodeVisitorFactory {
+
+    @Override
+    public NodeVisitor createVisitor(PebbleTemplate template) {
+        return new MacroAndBlockRegistrantNodeVisitor((PebbleTemplateImpl)template);
+    }
+
+}

--- a/src/main/java/com/mitchellbosecke/pebble/extension/debug/DebugExtension.java
+++ b/src/main/java/com/mitchellbosecke/pebble/extension/debug/DebugExtension.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of Pebble.
- * 
+ *
  * Copyright (c) 2014 by Mitchell Bösecke
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  ******************************************************************************/
@@ -12,14 +12,14 @@ import java.util.ArrayList;
 import java.util.List;
 
 import com.mitchellbosecke.pebble.extension.AbstractExtension;
-import com.mitchellbosecke.pebble.extension.NodeVisitor;
+import com.mitchellbosecke.pebble.extension.NodeVisitorFactory;
 
 public class DebugExtension extends AbstractExtension {
 
-    private final PrettyPrintNodeVisitor prettyPrinter = new PrettyPrintNodeVisitor();
+    private final PrettyPrintNodeVisitorFactory prettyPrinter = new PrettyPrintNodeVisitorFactory();
 
-    public List<NodeVisitor> getNodeVisitors() {
-        List<NodeVisitor> visitors = new ArrayList<>();
+    public List<NodeVisitorFactory> getNodeVisitors() {
+        List<NodeVisitorFactory> visitors = new ArrayList<>();
         visitors.add(prettyPrinter);
         return visitors;
     }

--- a/src/main/java/com/mitchellbosecke/pebble/extension/debug/PrettyPrintNodeVisitor.java
+++ b/src/main/java/com/mitchellbosecke/pebble/extension/debug/PrettyPrintNodeVisitor.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of Pebble.
- * 
+ *
  * Copyright (c) 2014 by Mitchell Bösecke
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  ******************************************************************************/
@@ -33,8 +33,13 @@ import com.mitchellbosecke.pebble.node.expression.GetAttributeExpression;
 import com.mitchellbosecke.pebble.node.expression.ParentFunctionExpression;
 import com.mitchellbosecke.pebble.node.expression.TernaryExpression;
 import com.mitchellbosecke.pebble.node.expression.UnaryExpression;
+import com.mitchellbosecke.pebble.template.PebbleTemplateImpl;
 
 public class PrettyPrintNodeVisitor extends AbstractNodeVisitor {
+
+    public PrettyPrintNodeVisitor(PebbleTemplateImpl template) {
+        super(template);
+    }
 
     private StringBuilder output = new StringBuilder();
 

--- a/src/main/java/com/mitchellbosecke/pebble/extension/debug/PrettyPrintNodeVisitorFactory.java
+++ b/src/main/java/com/mitchellbosecke/pebble/extension/debug/PrettyPrintNodeVisitorFactory.java
@@ -1,0 +1,19 @@
+package com.mitchellbosecke.pebble.extension.debug;
+
+import com.mitchellbosecke.pebble.extension.NodeVisitor;
+import com.mitchellbosecke.pebble.extension.NodeVisitorFactory;
+import com.mitchellbosecke.pebble.template.PebbleTemplate;
+import com.mitchellbosecke.pebble.template.PebbleTemplateImpl;
+
+/**
+ * Implementation of {@link NodeVisitorFactory} to create
+ * {@link PrettyPrintNodeVisitor}.
+ */
+public class PrettyPrintNodeVisitorFactory implements NodeVisitorFactory {
+
+    @Override
+    public NodeVisitor createVisitor(PebbleTemplate template) {
+       return new PrettyPrintNodeVisitor((PebbleTemplateImpl)template);
+    }
+
+}

--- a/src/main/java/com/mitchellbosecke/pebble/extension/escaper/EscaperExtension.java
+++ b/src/main/java/com/mitchellbosecke/pebble/extension/escaper/EscaperExtension.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of Pebble.
- * 
+ *
  * Copyright (c) 2014 by Mitchell Bösecke
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  ******************************************************************************/
@@ -15,7 +15,7 @@ import java.util.Map;
 
 import com.mitchellbosecke.pebble.extension.AbstractExtension;
 import com.mitchellbosecke.pebble.extension.Filter;
-import com.mitchellbosecke.pebble.extension.NodeVisitor;
+import com.mitchellbosecke.pebble.extension.NodeVisitorFactory;
 import com.mitchellbosecke.pebble.tokenParser.AutoEscapeTokenParser;
 import com.mitchellbosecke.pebble.tokenParser.TokenParser;
 
@@ -23,11 +23,11 @@ public class EscaperExtension extends AbstractExtension {
 
     private final EscapeFilter filter;
 
-    private final EscaperNodeVisitor visitor;
+    private final EscaperNodeVisitorFactory visitorFactory;
 
     public EscaperExtension() {
         this.filter = new EscapeFilter();
-        this.visitor = new EscaperNodeVisitor();
+        this.visitorFactory = new EscaperNodeVisitorFactory();
     }
 
     @Override
@@ -46,37 +46,45 @@ public class EscaperExtension extends AbstractExtension {
     }
 
     @Override
-    public List<NodeVisitor> getNodeVisitors() {
-        List<NodeVisitor> visitors = new ArrayList<>();
-        visitors.add(visitor);
+    public List<NodeVisitorFactory> getNodeVisitors() {
+        List<NodeVisitorFactory> visitors = new ArrayList<>();
+        visitors.add(visitorFactory);
         return visitors;
     }
 
     /**
      * Sets the default escaping strategy.
-     * 
+     *
      * @param strategy
      *            Escaping strategy
      */
     public void setDefaultStrategy(String strategy) {
+        // TODO: This method is dangerous, because the state of the filter is
+        // changed. When this is changed during the rendering of template this
+        // can lead to unexpected results.
         filter.setDefaultStrategy(strategy);
     }
 
     public void setAutoEscaping(boolean auto) {
-        visitor.pushAutoEscapeState(auto);
+        visitorFactory.setAutoEscaping(auto);
     }
 
     public void addSafeFilter(String filter) {
-        visitor.addSafeFilter(filter);
+        visitorFactory.addSafeFilter(filter);
     }
 
     /**
      * Adds a custom escaping strategy to the filter.
-     * 
-     * @param name Name of the escaping strategy
-     * @param strategy The implementation of the escaping strategy
+     *
+     * @param name
+     *            Name of the escaping strategy
+     * @param strategy
+     *            The implementation of the escaping strategy
      */
     public void addEscapingStrategy(String name, EscapingStrategy strategy) {
+        // TODO: This method is dangerous, because the state of the filter is
+        // changed. When this is changed during the rendering of template this
+        // can lead to unexpected results.
         filter.addEscapingStrategy(name, strategy);
     }
 

--- a/src/main/java/com/mitchellbosecke/pebble/extension/escaper/EscaperNodeVisitor.java
+++ b/src/main/java/com/mitchellbosecke/pebble/extension/escaper/EscaperNodeVisitor.java
@@ -1,16 +1,19 @@
 /*******************************************************************************
  * This file is part of Pebble.
- * 
+ *
  * Copyright (c) 2014 by Mitchell Bösecke
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  ******************************************************************************/
 package com.mitchellbosecke.pebble.extension.escaper;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Set;
 
 import com.mitchellbosecke.pebble.extension.AbstractNodeVisitor;
 import com.mitchellbosecke.pebble.node.ArgumentsNode;
@@ -25,6 +28,7 @@ import com.mitchellbosecke.pebble.node.expression.FunctionOrMacroInvocationExpre
 import com.mitchellbosecke.pebble.node.expression.LiteralStringExpression;
 import com.mitchellbosecke.pebble.node.expression.ParentFunctionExpression;
 import com.mitchellbosecke.pebble.node.expression.TernaryExpression;
+import com.mitchellbosecke.pebble.template.PebbleTemplateImpl;
 
 public class EscaperNodeVisitor extends AbstractNodeVisitor {
 
@@ -32,12 +36,12 @@ public class EscaperNodeVisitor extends AbstractNodeVisitor {
 
     private final LinkedList<Boolean> active = new LinkedList<>();
 
-    private final List<String> safeFilters = new ArrayList<>();
+    private final Set<String> safeFilters;
 
-    public EscaperNodeVisitor() {
-        safeFilters.add("raw");
-        safeFilters.add("escape");
-        safeFilters.add("date");
+    public EscaperNodeVisitor(PebbleTemplateImpl template, List<String> safeFilters, boolean autoEscapting) {
+        super(template);
+        this.safeFilters = Collections.unmodifiableSet(new LinkedHashSet<>(safeFilters));
+        this.pushAutoEscapeState(autoEscapting);
     }
 
     @Override
@@ -130,10 +134,6 @@ public class EscaperNodeVisitor extends AbstractNodeVisitor {
         }
 
         return safe;
-    }
-
-    public void addSafeFilter(String filter) {
-        this.safeFilters.add(filter);
     }
 
     public void pushAutoEscapeState(boolean auto) {

--- a/src/main/java/com/mitchellbosecke/pebble/extension/escaper/EscaperNodeVisitorFactory.java
+++ b/src/main/java/com/mitchellbosecke/pebble/extension/escaper/EscaperNodeVisitorFactory.java
@@ -1,0 +1,42 @@
+package com.mitchellbosecke.pebble.extension.escaper;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.mitchellbosecke.pebble.extension.NodeVisitor;
+import com.mitchellbosecke.pebble.extension.NodeVisitorFactory;
+import com.mitchellbosecke.pebble.template.PebbleTemplate;
+import com.mitchellbosecke.pebble.template.PebbleTemplateImpl;
+
+/**
+ * Factory class for creating {@link EscaperNodeVisitor}.
+ *
+ * @author Thomas Hunziker
+ *
+ */
+public class EscaperNodeVisitorFactory implements NodeVisitorFactory{
+
+    private final List<String> safeFilters = new ArrayList<>();
+    private boolean autoEscaping = true;
+
+    public EscaperNodeVisitorFactory() {
+        safeFilters.add("raw");
+        safeFilters.add("escape");
+        safeFilters.add("date");
+    }
+
+    @Override
+    public NodeVisitor createVisitor(PebbleTemplate template) {
+        return new EscaperNodeVisitor((PebbleTemplateImpl)template, safeFilters, this.autoEscaping);
+    }
+
+    public void addSafeFilter(String filter) {
+        this.safeFilters.add(filter);
+    }
+
+    public void setAutoEscaping(boolean auto) {
+        autoEscaping = auto;
+    }
+
+
+}

--- a/src/main/java/com/mitchellbosecke/pebble/lexer/Lexer.java
+++ b/src/main/java/com/mitchellbosecke/pebble/lexer/Lexer.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of Pebble.
- * 
+ *
  * Copyright (c) 2014 by Mitchell Bösecke
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  ******************************************************************************/
@@ -15,70 +15,4 @@ import com.mitchellbosecke.pebble.error.ParserException;
 public interface Lexer {
 
     TokenStream tokenize(Reader templateReader, String name) throws ParserException;
-
-    /**
-     * @return the commentOpenDelimiter
-     */
-    String getCommentOpenDelimiter();
-
-    /**
-     * @param commentOpenDelimiter
-     *            the commentOpenDelimiter to set
-     */
-    void setCommentOpenDelimiter(String commentOpenDelimiter);
-
-    /**
-     * @return the commentCloseDelimiter
-     */
-    String getCommentCloseDelimiter();
-
-    /**
-     * @param commentCloseDelimiter
-     *            the commentCloseDelimiter to set
-     */
-    void setCommentCloseDelimiter(String commentCloseDelimiter);
-
-    /**
-     * @return the executeOpenDelimiter
-     */
-    String getExecuteOpenDelimiter();
-
-    /**
-     * @param executeOpenDelimiter
-     *            the executeOpenDelimiter to set
-     */
-    void setExecuteOpenDelimiter(String executeOpenDelimiter);
-
-    /**
-     * @return the executeCloseDelimiter
-     */
-    String getExecuteCloseDelimiter();
-
-    /**
-     * @param executeCloseDelimiter
-     *            the executeCloseDelimiter to set
-     */
-    void setExecuteCloseDelimiter(String executeCloseDelimiter);
-
-    /**
-     * @return the printOpenDelimiter
-     */
-    String getPrintOpenDelimiter();
-
-    /**
-     * @param printOpenDelimiter
-     *            the printOpenDelimiter to set
-     */
-    void setPrintOpenDelimiter(String printOpenDelimiter);
-
-    /**
-     * @return the printCloseDelimiter
-     */
-    String getPrintCloseDelimiter();
-
-    /**
-     * @param printCloseDelimiter
-     *            the printCloseDelimiter to set
-     */
-    void setPrintCloseDelimiter(String printCloseDelimiter);
 }

--- a/src/main/java/com/mitchellbosecke/pebble/lexer/Syntax.java
+++ b/src/main/java/com/mitchellbosecke/pebble/lexer/Syntax.java
@@ -1,0 +1,290 @@
+package com.mitchellbosecke.pebble.lexer;
+
+import java.util.regex.Pattern;
+
+/**
+ * The syntax describes the different syntax parts of the Pebble language.
+ *
+ * <p>
+ * This object is immutable after the creation. This is to make sure the syntax
+ * cannot be changed during the execution.
+ */
+public final class Syntax {
+
+    private final String delimiterCommentOpen;
+
+    private final String delimiterCommentClose;
+
+    private final String delimiterExecuteOpen;
+
+    private final String delimiterExecuteClose;
+
+    private final String delimiterPrintOpen;
+
+    private final String delimiterPrintClose;
+
+    private final String whitespaceTrim;
+
+    /**
+     * The regular expressions used to find the different delimiters
+     */
+    private final Pattern regexPrintClose;
+
+    private final Pattern regexExecuteClose;
+
+    private final Pattern regexCommentClose;
+
+    private final Pattern regexStartDelimiters;
+
+    private final Pattern regexLeadingWhitespaceTrim;
+
+    private final Pattern regexTrailingWhitespaceTrim;
+
+    /**
+     * Regular expressions used to find "verbatim" and "endverbatim" tags.
+     */
+    private final Pattern regexVerbatimStart;
+
+    private final Pattern regexVerbatimEnd;
+
+    private static final String POSSIBLE_NEW_LINE = "(\r\n|\n\r|\r|\n|\u0085|\u2028|\u2029)?";
+
+    public Syntax(final String delimiterCommentOpen, final String delimiterCommentClose,
+            final String delimiterExecuteOpen, final String delimiterExecuteClose, final String delimiterPrintOpen,
+            final String delimiterPrintClose, final String whitespaceTrim) {
+        this.delimiterCommentClose = delimiterCommentClose;
+        this.delimiterCommentOpen = delimiterCommentOpen;
+        this.delimiterExecuteOpen = delimiterExecuteOpen;
+        this.delimiterExecuteClose = delimiterExecuteClose;
+        this.delimiterPrintOpen = delimiterPrintOpen;
+        this.delimiterPrintClose = delimiterPrintClose;
+        this.whitespaceTrim = whitespaceTrim;
+
+        // regexes used to find the individual delimiters
+        this.regexPrintClose = Pattern.compile("^\\s*" + Pattern.quote(whitespaceTrim) + "?"
+                + Pattern.quote(delimiterPrintClose) + POSSIBLE_NEW_LINE);
+        this.regexExecuteClose = Pattern.compile("^\\s*" + Pattern.quote(whitespaceTrim) + "?"
+                + Pattern.quote(delimiterExecuteClose) + POSSIBLE_NEW_LINE);
+        this.regexCommentClose = Pattern.compile(Pattern.quote(delimiterCommentClose) + POSSIBLE_NEW_LINE);
+
+        // combination regex used to find the next START delimiter of any kind
+        this.regexStartDelimiters = Pattern.compile(Pattern.quote(delimiterPrintOpen) + "|"
+                + Pattern.quote(delimiterExecuteOpen) + "|" + Pattern.quote(delimiterCommentOpen));
+
+        // regex to find the verbatim tag
+        this.regexVerbatimStart = Pattern.compile("^\\s*verbatim\\s*(" + Pattern.quote(whitespaceTrim) + ")?"
+                + Pattern.quote(delimiterExecuteClose) + POSSIBLE_NEW_LINE);
+        this.regexVerbatimEnd = Pattern.compile(Pattern.quote(delimiterExecuteOpen) + "("
+                + Pattern.quote(whitespaceTrim) + ")?" + "\\s*endverbatim\\s*(" + Pattern.quote(whitespaceTrim) + ")?"
+                + Pattern.quote(delimiterExecuteClose) + POSSIBLE_NEW_LINE);
+
+        // regex for the whitespace trim character
+        this.regexLeadingWhitespaceTrim = Pattern.compile(Pattern.quote(whitespaceTrim) + "\\s+");
+        this.regexTrailingWhitespaceTrim = Pattern.compile("^\\s*" + Pattern.quote(whitespaceTrim) + "("
+                + Pattern.quote(delimiterPrintClose) + "|" + Pattern.quote(delimiterExecuteClose) + "|"
+                + Pattern.quote(delimiterCommentClose) + ")");
+
+    }
+
+    /**
+     * @return the commentOpenDelimiter
+     */
+    public String getCommentOpenDelimiter() {
+        return delimiterCommentOpen;
+    }
+
+    /**
+     * @return the commentCloseDelimiter
+     */
+    public String getCommentCloseDelimiter() {
+        return delimiterCommentClose;
+    }
+
+    /**
+     * @return the executeOpenDelimiter
+     */
+    public String getExecuteOpenDelimiter() {
+        return delimiterExecuteOpen;
+    }
+
+    /**
+     * @return the executeCloseDelimiter
+     */
+    public String getExecuteCloseDelimiter() {
+        return delimiterExecuteClose;
+    }
+
+    /**
+     * @return the printOpenDelimiter
+     */
+    public String getPrintOpenDelimiter() {
+        return delimiterPrintOpen;
+    }
+
+    /**
+     * @return the printCloseDelimiter
+     */
+    public String getPrintCloseDelimiter() {
+        return delimiterPrintClose;
+    }
+
+    public String getWhitespaceTrim() {
+        return whitespaceTrim;
+    }
+
+    Pattern getRegexPrintClose() {
+        return regexPrintClose;
+    }
+
+    Pattern getRegexExecuteClose() {
+        return regexExecuteClose;
+    }
+
+    Pattern getRegexCommentClose() {
+        return regexCommentClose;
+    }
+
+    Pattern getRegexStartDelimiters() {
+        return regexStartDelimiters;
+    }
+
+    Pattern getRegexLeadingWhitespaceTrim() {
+        return regexLeadingWhitespaceTrim;
+    }
+
+    Pattern getRegexTrailingWhitespaceTrim() {
+        return regexTrailingWhitespaceTrim;
+    }
+
+    Pattern getRegexVerbatimEnd() {
+        return regexVerbatimEnd;
+    }
+
+    Pattern getRegexVerbatimStart() {
+        return regexVerbatimStart;
+    }
+
+    /**
+     * Helper class to create new instances of {@link Syntax}.
+     */
+    public static class Builder {
+
+        private String delimiterCommentOpen = "{#";
+
+        private String delimiterCommentClose = "#}";
+
+        private String delimiterExecuteOpen = "{%";
+
+        private String delimiterExecuteClose = "%}";
+
+        private String delimiterPrintOpen = "{{";
+
+        private String delimiterPrintClose = "}}";
+
+        private String whitespaceTrim = "-";
+
+        /**
+         * @return the commentOpenDelimiter
+         */
+        public String getCommentOpenDelimiter() {
+            return delimiterCommentOpen;
+        }
+
+        /**
+         * @param commentOpenDelimiter
+         *            the commentOpenDelimiter to set
+         */
+        public void setCommentOpenDelimiter(String commentOpenDelimiter) {
+            this.delimiterCommentOpen = commentOpenDelimiter;
+        }
+
+        /**
+         * @return the commentCloseDelimiter
+         */
+        public String getCommentCloseDelimiter() {
+            return delimiterCommentClose;
+        }
+
+        /**
+         * @param commentCloseDelimiter
+         *            the commentCloseDelimiter to set
+         */
+        public void setCommentCloseDelimiter(String commentCloseDelimiter) {
+            this.delimiterCommentClose = commentCloseDelimiter;
+        }
+
+        /**
+         * @return the executeOpenDelimiter
+         */
+        public String getExecuteOpenDelimiter() {
+            return delimiterExecuteOpen;
+        }
+
+        /**
+         * @param executeOpenDelimiter
+         *            the executeOpenDelimiter to set
+         */
+        public void setExecuteOpenDelimiter(String executeOpenDelimiter) {
+            this.delimiterExecuteOpen = executeOpenDelimiter;
+        }
+
+        /**
+         * @return the executeCloseDelimiter
+         */
+        public String getExecuteCloseDelimiter() {
+            return delimiterExecuteClose;
+        }
+
+        /**
+         * @param executeCloseDelimiter
+         *            the executeCloseDelimiter to set
+         */
+        public void setExecuteCloseDelimiter(String executeCloseDelimiter) {
+            this.delimiterExecuteClose = executeCloseDelimiter;
+        }
+
+        /**
+         * @return the printOpenDelimiter
+         */
+        public String getPrintOpenDelimiter() {
+            return delimiterPrintOpen;
+        }
+
+        /**
+         * @param printOpenDelimiter
+         *            the printOpenDelimiter to set
+         */
+        public void setPrintOpenDelimiter(String printOpenDelimiter) {
+            this.delimiterPrintOpen = printOpenDelimiter;
+        }
+
+        /**
+         * @return the printCloseDelimiter
+         */
+        public String getPrintCloseDelimiter() {
+            return delimiterPrintClose;
+        }
+
+        /**
+         * @param printCloseDelimiter
+         *            the printCloseDelimiter to set
+         */
+        public void setPrintCloseDelimiter(String printCloseDelimiter) {
+            this.delimiterPrintClose = printCloseDelimiter;
+        }
+
+        public String getWhitespaceTrim() {
+            return whitespaceTrim;
+        }
+
+        public void setWhitespaceTrim(String whitespaceTrim) {
+            this.whitespaceTrim = whitespaceTrim;
+        }
+
+        public Syntax build() {
+            return new Syntax(delimiterCommentOpen, delimiterCommentClose, delimiterExecuteOpen, delimiterExecuteClose,
+                    delimiterPrintOpen, delimiterPrintClose, whitespaceTrim);
+        }
+    }
+
+}

--- a/src/main/java/com/mitchellbosecke/pebble/parser/ParserImpl.java
+++ b/src/main/java/com/mitchellbosecke/pebble/parser/ParserImpl.java
@@ -174,8 +174,7 @@ public class ParserImpl implements Parser {
                             token.getLineNumber(), stream.getFilename());
                 }
 
-                tokenParser.setParser(this);
-                RenderableNode node = tokenParser.parse(token);
+                RenderableNode node = tokenParser.parse(token, this);
 
                 // node might be null (ex. "extend" token parser)
                 if (node != null) {

--- a/src/main/java/com/mitchellbosecke/pebble/parser/ParserImpl.java
+++ b/src/main/java/com/mitchellbosecke/pebble/parser/ParserImpl.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of Pebble.
- * 
+ *
  * Copyright (c) 2014 by Mitchell Bösecke
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  ******************************************************************************/
@@ -55,7 +55,7 @@ public class ParserImpl implements Parser {
 
     /**
      * Constructor
-     * 
+     *
      * @param engine
      *            The main PebbleEngine that this parser is working for
      */
@@ -91,7 +91,7 @@ public class ParserImpl implements Parser {
     /**
      * The main method for the parser. This method does the work of converting
      * a TokenStream into a Node
-     * 
+     *
      * @param stopCondition	A stopping condition provided by a token parser
      * @return Node		The root node of the generated Abstract Syntax Tree
      */
@@ -131,7 +131,7 @@ public class ParserImpl implements Parser {
                 nodes.add(new PrintNode(expression, token.getLineNumber()));
 
                 // we expect to see a print closing delimiter
-                stream.expect(Token.Type.PRINT_END, engine.getLexer().getPrintCloseDelimiter());
+                stream.expect(Token.Type.PRINT_END, engine.getSyntax().getPrintCloseDelimiter());
 
                 break;
 
@@ -145,7 +145,7 @@ public class ParserImpl implements Parser {
 
                 /*
                  * We expect a name token at the beginning of every block.
-                 * 
+                 *
                  * We do not use stream.expect() because it consumes the current
                  * token. The current token may be needed by a token parser
                  * which has provided a stopping condition. Ex. the 'if' token

--- a/src/main/java/com/mitchellbosecke/pebble/template/PebbleTemplate.java
+++ b/src/main/java/com/mitchellbosecke/pebble/template/PebbleTemplate.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of Pebble.
- * 
+ *
  * Copyright (c) 2014 by Mitchell Bösecke
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  ******************************************************************************/
@@ -24,4 +24,5 @@ public interface PebbleTemplate {
     void evaluate(Writer writer, Map<String, Object> map) throws PebbleException, IOException;
 
     void evaluate(Writer writer, Map<String, Object> map, Locale locale) throws PebbleException, IOException;
+
 }

--- a/src/main/java/com/mitchellbosecke/pebble/tokenParser/AbstractTokenParser.java
+++ b/src/main/java/com/mitchellbosecke/pebble/tokenParser/AbstractTokenParser.java
@@ -1,22 +1,14 @@
 /*******************************************************************************
  * This file is part of Pebble.
- * 
+ *
  * Copyright (c) 2014 by Mitchell Bösecke
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  ******************************************************************************/
 package com.mitchellbosecke.pebble.tokenParser;
 
-import com.mitchellbosecke.pebble.parser.Parser;
 
 public abstract class AbstractTokenParser implements TokenParser {
-
-    protected Parser parser;
-
-    @Override
-    public void setParser(Parser parser) {
-        this.parser = parser;
-    }
 
 }

--- a/src/main/java/com/mitchellbosecke/pebble/tokenParser/AutoEscapeTokenParser.java
+++ b/src/main/java/com/mitchellbosecke/pebble/tokenParser/AutoEscapeTokenParser.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of Pebble.
- * 
+ *
  * Copyright (c) 2014 by Mitchell Bösecke
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  ******************************************************************************/
@@ -14,13 +14,14 @@ import com.mitchellbosecke.pebble.lexer.TokenStream;
 import com.mitchellbosecke.pebble.node.AutoEscapeNode;
 import com.mitchellbosecke.pebble.node.BodyNode;
 import com.mitchellbosecke.pebble.node.RenderableNode;
+import com.mitchellbosecke.pebble.parser.Parser;
 import com.mitchellbosecke.pebble.parser.StoppingCondition;
 
 public class AutoEscapeTokenParser extends AbstractTokenParser {
 
     @Override
-    public RenderableNode parse(Token token) throws ParserException {
-        TokenStream stream = this.parser.getStream();
+    public RenderableNode parse(Token token, Parser parser) throws ParserException {
+        TokenStream stream = parser.getStream();
         int lineNumber = token.getLineNumber();
 
         String strategy = null;
@@ -44,7 +45,7 @@ public class AutoEscapeTokenParser extends AbstractTokenParser {
         stream.expect(Token.Type.EXECUTE_END);
 
         // now we parse the block body
-        BodyNode body = this.parser.subparse(new StoppingCondition() {
+        BodyNode body = parser.subparse(new StoppingCondition() {
 
             @Override
             public boolean evaluate(Token token) {

--- a/src/main/java/com/mitchellbosecke/pebble/tokenParser/BlockTokenParser.java
+++ b/src/main/java/com/mitchellbosecke/pebble/tokenParser/BlockTokenParser.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of Pebble.
- * 
+ *
  * Copyright (c) 2014 by Mitchell Bösecke
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  ******************************************************************************/
@@ -14,13 +14,14 @@ import com.mitchellbosecke.pebble.lexer.TokenStream;
 import com.mitchellbosecke.pebble.node.BlockNode;
 import com.mitchellbosecke.pebble.node.BodyNode;
 import com.mitchellbosecke.pebble.node.RenderableNode;
+import com.mitchellbosecke.pebble.parser.Parser;
 import com.mitchellbosecke.pebble.parser.StoppingCondition;
 
 public class BlockTokenParser extends AbstractTokenParser {
 
     @Override
-    public RenderableNode parse(Token token) throws ParserException {
-        TokenStream stream = this.parser.getStream();
+    public RenderableNode parse(Token token, Parser parser) throws ParserException {
+        TokenStream stream = parser.getStream();
         int lineNumber = token.getLineNumber();
 
         // skip over the 'block' token to the name token
@@ -43,17 +44,17 @@ public class BlockTokenParser extends AbstractTokenParser {
 
         stream.expect(Token.Type.EXECUTE_END);
 
-        this.parser.pushBlockStack(name);
+        parser.pushBlockStack(name);
 
         // now we parse the block body
-        BodyNode blockBody = this.parser.subparse(new StoppingCondition() {
+        BodyNode blockBody = parser.subparse(new StoppingCondition() {
 
             @Override
             public boolean evaluate(Token token) {
                 return token.test(Token.Type.NAME, "endblock");
             }
         });
-        this.parser.popBlockStack();
+        parser.popBlockStack();
 
         // skip the 'endblock' token
         stream.next();

--- a/src/main/java/com/mitchellbosecke/pebble/tokenParser/ExtendsTokenParser.java
+++ b/src/main/java/com/mitchellbosecke/pebble/tokenParser/ExtendsTokenParser.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of Pebble.
- * 
+ *
  * Copyright (c) 2014 by Mitchell Bösecke
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  ******************************************************************************/
@@ -14,12 +14,13 @@ import com.mitchellbosecke.pebble.lexer.TokenStream;
 import com.mitchellbosecke.pebble.node.ExtendsNode;
 import com.mitchellbosecke.pebble.node.RenderableNode;
 import com.mitchellbosecke.pebble.node.expression.Expression;
+import com.mitchellbosecke.pebble.parser.Parser;
 
 public class ExtendsTokenParser extends AbstractTokenParser {
 
     @Override
-    public RenderableNode parse(Token token) throws ParserException {
-        TokenStream stream = this.parser.getStream();
+    public RenderableNode parse(Token token, Parser parser) throws ParserException {
+        TokenStream stream = parser.getStream();
         int lineNumber = token.getLineNumber();
 
         // skip the 'extends' token

--- a/src/main/java/com/mitchellbosecke/pebble/tokenParser/FilterTokenParser.java
+++ b/src/main/java/com/mitchellbosecke/pebble/tokenParser/FilterTokenParser.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of Pebble.
- * 
+ *
  * Copyright (c) 2014 by Mitchell Bösecke
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  ******************************************************************************/
@@ -21,6 +21,7 @@ import com.mitchellbosecke.pebble.node.RenderableNode;
 import com.mitchellbosecke.pebble.node.expression.Expression;
 import com.mitchellbosecke.pebble.node.expression.FilterExpression;
 import com.mitchellbosecke.pebble.node.expression.RenderableNodeExpression;
+import com.mitchellbosecke.pebble.parser.Parser;
 import com.mitchellbosecke.pebble.parser.StoppingCondition;
 
 /**
@@ -30,44 +31,44 @@ import com.mitchellbosecke.pebble.parser.StoppingCondition;
 public class FilterTokenParser extends AbstractTokenParser {
 
     @Override
-    public RenderableNode parse(Token token) throws ParserException {
-        TokenStream stream = this.parser.getStream();
+    public RenderableNode parse(Token token, Parser parser) throws ParserException {
+        TokenStream stream = parser.getStream();
         int lineNumber = token.getLineNumber();
 
         // skip the 'filter' token
         stream.next();
 
         List<Expression<?>> filterInvocationExpressions = new ArrayList<>();
-        
-        filterInvocationExpressions.add(this.parser.getExpressionParser().parseFilterInvocationExpression());
-        
+
+        filterInvocationExpressions.add(parser.getExpressionParser().parseFilterInvocationExpression());
+
         while(stream.current().test(Type.OPERATOR, "|")){
             // skip the '|' token
             stream.next();
-            filterInvocationExpressions.add(this.parser.getExpressionParser().parseFilterInvocationExpression());
+            filterInvocationExpressions.add(parser.getExpressionParser().parseFilterInvocationExpression());
         }
 
         stream.expect(Token.Type.EXECUTE_END);
-        
-        BodyNode body = this.parser.subparse(endFilter);
-        
+
+        BodyNode body = parser.subparse(endFilter);
+
         stream.next();
         stream.expect(Token.Type.EXECUTE_END);
-        
+
         Expression<?> lastExpression = new RenderableNodeExpression(body);
-        
+
         for(Expression<?> filterInvocationExpression : filterInvocationExpressions){
-            
+
             FilterExpression filterExpression = new FilterExpression();
             filterExpression.setRight(filterInvocationExpression);
             filterExpression.setLeft(lastExpression);
-            
+
             lastExpression = filterExpression;
         }
 
         return new PrintNode(lastExpression, lineNumber);
     }
-    
+
     private StoppingCondition endFilter = new StoppingCondition() {
 
         @Override

--- a/src/main/java/com/mitchellbosecke/pebble/tokenParser/FlushTokenParser.java
+++ b/src/main/java/com/mitchellbosecke/pebble/tokenParser/FlushTokenParser.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of Pebble.
- * 
+ *
  * Copyright (c) 2014 by Mitchell Bösecke
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  ******************************************************************************/
@@ -13,13 +13,14 @@ import com.mitchellbosecke.pebble.lexer.Token;
 import com.mitchellbosecke.pebble.lexer.TokenStream;
 import com.mitchellbosecke.pebble.node.FlushNode;
 import com.mitchellbosecke.pebble.node.RenderableNode;
+import com.mitchellbosecke.pebble.parser.Parser;
 
 public class FlushTokenParser extends AbstractTokenParser {
 
     @Override
-    public RenderableNode parse(Token token) throws ParserException {
+    public RenderableNode parse(Token token, Parser parser) throws ParserException {
 
-        TokenStream stream = this.parser.getStream();
+        TokenStream stream = parser.getStream();
         int lineNumber = token.getLineNumber();
 
         // skip over the 'flush' token

--- a/src/main/java/com/mitchellbosecke/pebble/tokenParser/ForTokenParser.java
+++ b/src/main/java/com/mitchellbosecke/pebble/tokenParser/ForTokenParser.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of Pebble.
- * 
+ *
  * Copyright (c) 2014 by Mitchell Bösecke
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  ******************************************************************************/
@@ -15,29 +15,30 @@ import com.mitchellbosecke.pebble.node.BodyNode;
 import com.mitchellbosecke.pebble.node.ForNode;
 import com.mitchellbosecke.pebble.node.RenderableNode;
 import com.mitchellbosecke.pebble.node.expression.Expression;
+import com.mitchellbosecke.pebble.parser.Parser;
 import com.mitchellbosecke.pebble.parser.StoppingCondition;
 
 public class ForTokenParser extends AbstractTokenParser {
 
     @Override
-    public RenderableNode parse(Token token) throws ParserException {
-        TokenStream stream = this.parser.getStream();
+    public RenderableNode parse(Token token, Parser parser) throws ParserException {
+        TokenStream stream = parser.getStream();
         int lineNumber = token.getLineNumber();
 
         // skip the 'for' token
         stream.next();
 
         // get the iteration variable
-        String iterationVariable = this.parser.getExpressionParser().parseNewVariableName();
+        String iterationVariable = parser.getExpressionParser().parseNewVariableName();
 
         stream.expect(Token.Type.NAME, "in");
 
         // get the iterable variable
-        Expression<?> iterable = this.parser.getExpressionParser().parseExpression();
+        Expression<?> iterable = parser.getExpressionParser().parseExpression();
 
         stream.expect(Token.Type.EXECUTE_END);
 
-        BodyNode body = this.parser.subparse(decideForFork);
+        BodyNode body = parser.subparse(decideForFork);
 
         BodyNode elseBody = null;
 
@@ -45,7 +46,7 @@ public class ForTokenParser extends AbstractTokenParser {
             // skip the 'else' token
             stream.next();
             stream.expect(Token.Type.EXECUTE_END);
-            elseBody = this.parser.subparse(decideForEnd);
+            elseBody = parser.subparse(decideForEnd);
         }
 
         // skip the 'endfor' token

--- a/src/main/java/com/mitchellbosecke/pebble/tokenParser/IfTokenParser.java
+++ b/src/main/java/com/mitchellbosecke/pebble/tokenParser/IfTokenParser.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of Pebble.
- * 
+ *
  * Copyright (c) 2014 by Mitchell Bösecke
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  ******************************************************************************/
@@ -18,14 +18,15 @@ import com.mitchellbosecke.pebble.node.BodyNode;
 import com.mitchellbosecke.pebble.node.IfNode;
 import com.mitchellbosecke.pebble.node.RenderableNode;
 import com.mitchellbosecke.pebble.node.expression.Expression;
+import com.mitchellbosecke.pebble.parser.Parser;
 import com.mitchellbosecke.pebble.parser.StoppingCondition;
 import com.mitchellbosecke.pebble.utils.Pair;
 
 public class IfTokenParser extends AbstractTokenParser {
 
     @Override
-    public RenderableNode parse(Token token) throws ParserException {
-        TokenStream stream = this.parser.getStream();
+    public RenderableNode parse(Token token, Parser parser) throws ParserException {
+        TokenStream stream = parser.getStream();
         int lineNumber = token.getLineNumber();
 
         // skip the 'if' token
@@ -33,11 +34,11 @@ public class IfTokenParser extends AbstractTokenParser {
 
         List<Pair<Expression<?>, BodyNode>> conditionsWithBodies = new ArrayList<>();
 
-        Expression<?> expression = this.parser.getExpressionParser().parseExpression();
+        Expression<?> expression = parser.getExpressionParser().parseExpression();
 
         stream.expect(Token.Type.EXECUTE_END);
 
-        BodyNode body = this.parser.subparse(decideIfFork);
+        BodyNode body = parser.subparse(decideIfFork);
 
         conditionsWithBodies.add(new Pair<Expression<?>, BodyNode>(expression, body));
 
@@ -48,14 +49,14 @@ public class IfTokenParser extends AbstractTokenParser {
             case "else":
                 stream.next();
                 stream.expect(Token.Type.EXECUTE_END);
-                elseBody = this.parser.subparse(decideIfEnd);
+                elseBody = parser.subparse(decideIfEnd);
                 break;
 
             case "elseif":
                 stream.next();
-                expression = this.parser.getExpressionParser().parseExpression();
+                expression = parser.getExpressionParser().parseExpression();
                 stream.expect(Token.Type.EXECUTE_END);
-                body = this.parser.subparse(decideIfFork);
+                body = parser.subparse(decideIfFork);
                 conditionsWithBodies.add(new Pair<Expression<?>, BodyNode>(expression, body));
                 break;
 

--- a/src/main/java/com/mitchellbosecke/pebble/tokenParser/ImportTokenParser.java
+++ b/src/main/java/com/mitchellbosecke/pebble/tokenParser/ImportTokenParser.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of Pebble.
- * 
+ *
  * Copyright (c) 2014 by Mitchell Bösecke
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  ******************************************************************************/
@@ -14,19 +14,20 @@ import com.mitchellbosecke.pebble.lexer.TokenStream;
 import com.mitchellbosecke.pebble.node.ImportNode;
 import com.mitchellbosecke.pebble.node.RenderableNode;
 import com.mitchellbosecke.pebble.node.expression.Expression;
+import com.mitchellbosecke.pebble.parser.Parser;
 
 public class ImportTokenParser extends AbstractTokenParser {
 
     @Override
-    public RenderableNode parse(Token token) throws ParserException {
+    public RenderableNode parse(Token token, Parser parser) throws ParserException {
 
-        TokenStream stream = this.parser.getStream();
+        TokenStream stream = parser.getStream();
         int lineNumber = token.getLineNumber();
 
         // skip over the 'import' token
         stream.next();
 
-        Expression<?> importExpression = this.parser.getExpressionParser().parseExpression();
+        Expression<?> importExpression = parser.getExpressionParser().parseExpression();
 
         stream.expect(Token.Type.EXECUTE_END);
 

--- a/src/main/java/com/mitchellbosecke/pebble/tokenParser/IncludeTokenParser.java
+++ b/src/main/java/com/mitchellbosecke/pebble/tokenParser/IncludeTokenParser.java
@@ -15,19 +15,20 @@ import com.mitchellbosecke.pebble.node.IncludeNode;
 import com.mitchellbosecke.pebble.node.RenderableNode;
 import com.mitchellbosecke.pebble.node.expression.Expression;
 import com.mitchellbosecke.pebble.node.expression.MapExpression;
+import com.mitchellbosecke.pebble.parser.Parser;
 
 public class IncludeTokenParser extends AbstractTokenParser {
 
     @Override
-    public RenderableNode parse(Token token) throws ParserException {
+    public RenderableNode parse(Token token, Parser parser) throws ParserException {
 
-        TokenStream stream = this.parser.getStream();
+        TokenStream stream = parser.getStream();
         int lineNumber = token.getLineNumber();
 
         // skip over the 'include' token
         stream.next();
 
-        Expression<?> includeExpression = this.parser.getExpressionParser().parseExpression();
+        Expression<?> includeExpression = parser.getExpressionParser().parseExpression();
 
         Token current = stream.current();
         MapExpression mapExpression = null;
@@ -38,13 +39,13 @@ public class IncludeTokenParser extends AbstractTokenParser {
             // Skip over 'with'
             stream.next();
 
-            Expression<?> parsedExpression = this.parser.getExpressionParser().parseExpression();
+            Expression<?> parsedExpression = parser.getExpressionParser().parseExpression();
 
             if (parsedExpression instanceof MapExpression) {
-                mapExpression = (MapExpression)parsedExpression;
+                mapExpression = (MapExpression) parsedExpression;
             } else {
-                throw new ParserException(null, String.format("Unexpected expression '%1s'.", parsedExpression.getClass()
-                        .getCanonicalName()), token.getLineNumber(), stream.getFilename());
+                throw new ParserException(null, String.format("Unexpected expression '%1s'.", parsedExpression
+                        .getClass().getCanonicalName()), token.getLineNumber(), stream.getFilename());
             }
 
         }

--- a/src/main/java/com/mitchellbosecke/pebble/tokenParser/MacroTokenParser.java
+++ b/src/main/java/com/mitchellbosecke/pebble/tokenParser/MacroTokenParser.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of Pebble.
- * 
+ *
  * Copyright (c) 2014 by Mitchell Bösecke
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  ******************************************************************************/
@@ -15,26 +15,27 @@ import com.mitchellbosecke.pebble.node.ArgumentsNode;
 import com.mitchellbosecke.pebble.node.BodyNode;
 import com.mitchellbosecke.pebble.node.MacroNode;
 import com.mitchellbosecke.pebble.node.RenderableNode;
+import com.mitchellbosecke.pebble.parser.Parser;
 import com.mitchellbosecke.pebble.parser.StoppingCondition;
 
 public class MacroTokenParser extends AbstractTokenParser {
 
     @Override
-    public RenderableNode parse(Token token) throws ParserException {
+    public RenderableNode parse(Token token, Parser parser) throws ParserException {
 
-        TokenStream stream = this.parser.getStream();
+        TokenStream stream = parser.getStream();
 
         // skip over the 'macro' token
         stream.next();
 
         String macroName = stream.expect(Token.Type.NAME).getValue();
 
-        ArgumentsNode args = this.parser.getExpressionParser().parseArguments(true);
+        ArgumentsNode args = parser.getExpressionParser().parseArguments(true);
 
         stream.expect(Token.Type.EXECUTE_END);
 
         // parse the body
-        BodyNode body = this.parser.subparse(decideMacroEnd);
+        BodyNode body = parser.subparse(decideMacroEnd);
 
         // skip the 'endmacro' token
         stream.next();

--- a/src/main/java/com/mitchellbosecke/pebble/tokenParser/ParallelTokenParser.java
+++ b/src/main/java/com/mitchellbosecke/pebble/tokenParser/ParallelTokenParser.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of Pebble.
- * 
+ *
  * Copyright (c) 2014 by Mitchell Bösecke
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  ******************************************************************************/
@@ -14,13 +14,14 @@ import com.mitchellbosecke.pebble.lexer.TokenStream;
 import com.mitchellbosecke.pebble.node.BodyNode;
 import com.mitchellbosecke.pebble.node.ParallelNode;
 import com.mitchellbosecke.pebble.node.RenderableNode;
+import com.mitchellbosecke.pebble.parser.Parser;
 import com.mitchellbosecke.pebble.parser.StoppingCondition;
 
 public class ParallelTokenParser extends AbstractTokenParser {
 
     @Override
-    public RenderableNode parse(Token token) throws ParserException {
-        TokenStream stream = this.parser.getStream();
+    public RenderableNode parse(Token token, Parser parser) throws ParserException {
+        TokenStream stream = parser.getStream();
         int lineNumber = token.getLineNumber();
 
         // skip the 'parallel' token
@@ -28,7 +29,7 @@ public class ParallelTokenParser extends AbstractTokenParser {
 
         stream.expect(Token.Type.EXECUTE_END);
 
-        BodyNode body = this.parser.subparse(decideParallelEnd);
+        BodyNode body = parser.subparse(decideParallelEnd);
 
         // skip the 'endparallel' token
         stream.next();

--- a/src/main/java/com/mitchellbosecke/pebble/tokenParser/SetTokenParser.java
+++ b/src/main/java/com/mitchellbosecke/pebble/tokenParser/SetTokenParser.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of Pebble.
- * 
+ *
  * Copyright (c) 2014 by Mitchell Bösecke
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  ******************************************************************************/
@@ -14,22 +14,23 @@ import com.mitchellbosecke.pebble.lexer.TokenStream;
 import com.mitchellbosecke.pebble.node.RenderableNode;
 import com.mitchellbosecke.pebble.node.SetNode;
 import com.mitchellbosecke.pebble.node.expression.Expression;
+import com.mitchellbosecke.pebble.parser.Parser;
 
 public class SetTokenParser extends AbstractTokenParser {
 
     @Override
-    public RenderableNode parse(Token token) throws ParserException {
-        TokenStream stream = this.parser.getStream();
+    public RenderableNode parse(Token token, Parser parser) throws ParserException {
+        TokenStream stream = parser.getStream();
         int lineNumber = token.getLineNumber();
 
         // skip the 'set' token
         stream.next();
 
-        String name = this.parser.getExpressionParser().parseNewVariableName();
+        String name = parser.getExpressionParser().parseNewVariableName();
 
         stream.expect(Token.Type.PUNCTUATION, "=");
 
-        Expression<?> value = this.parser.getExpressionParser().parseExpression();
+        Expression<?> value = parser.getExpressionParser().parseExpression();
 
         stream.expect(Token.Type.EXECUTE_END);
 

--- a/src/main/java/com/mitchellbosecke/pebble/tokenParser/TokenParser.java
+++ b/src/main/java/com/mitchellbosecke/pebble/tokenParser/TokenParser.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of Pebble.
- * 
+ *
  * Copyright (c) 2014 by Mitchell Bösecke
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  ******************************************************************************/
@@ -17,9 +17,9 @@ import com.mitchellbosecke.pebble.parser.Parser;
  * A TokenParser is responsible for converting a stream of Tokens into a Node. A
  * TokenParser often has to temporarily delegate responsibility to Pebble's main
  * Parser or Pebble's ExpressionParser.
- * 
+ *
  * @author Mitchell
- * 
+ *
  */
 public interface TokenParser {
 
@@ -27,53 +27,43 @@ public interface TokenParser {
      * The "tag" is used to determine when to use a particular instance of a
      * TokenParser. For example, the TokenParser that handles the "block" tag
      * would return "block" with this method.
-     * 
+     *
      * @return The tag used to define this TokenParser.
      */
     String getTag();
 
     /**
-     * Each TokenParser instance will have access to the primary Pebble Parser
-     * before the parse(Token token) method is invoked.
-     * 
-     * The primary parser will provide the TokenStream which a TokenParser will
-     * require.
-     * 
-     * @param parser
-     *            The desired parser
-     */
-    void setParser(Parser parser);
-
-    /**
      * The TokenParser is responsible to convert all the necessary tokens into
      * appropriate Nodes. It can access tokens using parser.getTokenStream().
-     * 
+     *
      * The tag may be self contained like the "extends" tag or it may have a
      * start and end point with content in the middle like the "block" tag. If
      * it contains content in the middle, it can use
      * parser.subparse(stopCondition) to parse the middle content at which point
      * responsibility comes back to the TokenParser to parse the end point.
-     * 
+     *
      * It is the responsibility of the TokenParser to ensure that when it is
      * complete, the "current" token of the primary Parser's TokenStream is
      * pointing to the NEXT token. USUALLY this means the last statement in this
      * parse method, immediately prior to the return statement, is the following
      * which will consume one token:
-     * 
+     *
      * stream.expect(Token.Type.EXECUTE_END);
-     * 
+     *
      * Here are two relatively simple examples of how TokenParsers are
      * implemented:
-     * 
+     *
      * - self contained: com.mitchellbosecke.pebble.tokenParser.SetTokenParser -
      * middle content: com.mitchellbosecke.pebble.tokenParser.BlockTokenParser
-     * 
+     *
      * @param token
      *            The token to parse
+     * @param parser
+     *            the parser which should be used to parse the token
      * @return A node representation of the token
      * @throws ParserException
      *             Thrown if an error occurs while parsing the token
      */
-    RenderableNode parse(Token token) throws ParserException;
+    RenderableNode parse(Token token, Parser parser) throws ParserException;
 
 }

--- a/src/main/java/com/mitchellbosecke/pebble/tokenParser/VerbatimTokenParser.java
+++ b/src/main/java/com/mitchellbosecke/pebble/tokenParser/VerbatimTokenParser.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of Pebble.
- * 
+ *
  * Copyright (c) 2014 by Mitchell Bösecke
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  ******************************************************************************/
@@ -11,18 +11,19 @@ package com.mitchellbosecke.pebble.tokenParser;
 import com.mitchellbosecke.pebble.error.ParserException;
 import com.mitchellbosecke.pebble.lexer.Token;
 import com.mitchellbosecke.pebble.node.RenderableNode;
+import com.mitchellbosecke.pebble.parser.Parser;
 
 /**
  * This is just a dummy class to point developers into the right direction; the
  * verbatim tag had to be implemented directly into the lexer.
- * 
+ *
  * @author mbosecke
  *
  */
 public class VerbatimTokenParser extends AbstractTokenParser {
 
     @Override
-    public RenderableNode parse(Token token) throws ParserException {
+    public RenderableNode parse(Token token, Parser parser) throws ParserException {
 
         throw new UnsupportedOperationException();
     }

--- a/src/test/java/com/mitchellbosecke/pebble/AbstractTest.java
+++ b/src/test/java/com/mitchellbosecke/pebble/AbstractTest.java
@@ -8,16 +8,12 @@
  ******************************************************************************/
 package com.mitchellbosecke.pebble;
 
-import com.mitchellbosecke.pebble.lexer.Lexer;
 import com.mitchellbosecke.pebble.loader.Loader;
-import com.mitchellbosecke.pebble.parser.Parser;
 
 public abstract class AbstractTest {
 
 	protected final PebbleEngine pebble;
-	protected final Lexer lexer;
 	protected final Loader<?> loader;
-	protected final Parser parser;
 
 	public AbstractTest() {
 
@@ -26,8 +22,6 @@ public abstract class AbstractTest {
 		pebble.getLoader().setPrefix("templates");
 
 		loader = pebble.getLoader();
-		lexer = pebble.getLexer();
-		parser = pebble.getParser();
 	}
 
 }

--- a/src/test/java/com/mitchellbosecke/pebble/CoreOperatorsTest.java
+++ b/src/test/java/com/mitchellbosecke/pebble/CoreOperatorsTest.java
@@ -550,7 +550,7 @@ public class CoreOperatorsTest extends AbstractTest {
      */
     @Test
     public void testStringConcatenation() throws PebbleException, IOException {
-        Loader loader = new StringLoader();
+        Loader<?> loader = new StringLoader();
         PebbleEngine pebble = new PebbleEngine(loader);
 
         String source = "{{ name1 ~ name2 ~ name3 | lower }}";

--- a/src/test/java/com/mitchellbosecke/pebble/CoreTagsTest.java
+++ b/src/test/java/com/mitchellbosecke/pebble/CoreTagsTest.java
@@ -218,7 +218,7 @@ public class CoreTagsTest extends AbstractTest {
 
     @Test
     public void testForWithMap() throws PebbleException, IOException {
-        Loader loader = new StringLoader();
+        Loader<?> loader = new StringLoader();
         PebbleEngine pebble = new PebbleEngine(loader);
 
         Map<String, Integer> data = new LinkedHashMap<>();

--- a/src/test/java/com/mitchellbosecke/pebble/TestParallelParsing.java
+++ b/src/test/java/com/mitchellbosecke/pebble/TestParallelParsing.java
@@ -18,6 +18,7 @@ import com.mitchellbosecke.pebble.extension.NodeVisitor;
 import com.mitchellbosecke.pebble.lexer.Token;
 import com.mitchellbosecke.pebble.lexer.TokenStream;
 import com.mitchellbosecke.pebble.node.RenderableNode;
+import com.mitchellbosecke.pebble.parser.Parser;
 import com.mitchellbosecke.pebble.template.EvaluationContext;
 import com.mitchellbosecke.pebble.template.PebbleTemplate;
 import com.mitchellbosecke.pebble.template.PebbleTemplateImpl;
@@ -111,9 +112,9 @@ public class TestParallelParsing extends AbstractTest {
         }
 
         @Override
-        public RenderableNode parse(Token token) throws ParserException {
+        public RenderableNode parse(Token token, Parser parser) throws ParserException {
 
-            TokenStream stream = this.parser.getStream();
+            TokenStream stream = parser.getStream();
 
             // skip over the 'delay' token
             Token delayName = stream.next();

--- a/src/test/java/com/mitchellbosecke/pebble/TestParallelParsing.java
+++ b/src/test/java/com/mitchellbosecke/pebble/TestParallelParsing.java
@@ -1,0 +1,161 @@
+package com.mitchellbosecke.pebble;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.io.Writer;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.Test;
+
+import com.mitchellbosecke.pebble.error.ParserException;
+import com.mitchellbosecke.pebble.error.PebbleException;
+import com.mitchellbosecke.pebble.extension.AbstractExtension;
+import com.mitchellbosecke.pebble.extension.NodeVisitor;
+import com.mitchellbosecke.pebble.lexer.Token;
+import com.mitchellbosecke.pebble.lexer.TokenStream;
+import com.mitchellbosecke.pebble.node.RenderableNode;
+import com.mitchellbosecke.pebble.template.EvaluationContext;
+import com.mitchellbosecke.pebble.template.PebbleTemplate;
+import com.mitchellbosecke.pebble.template.PebbleTemplateImpl;
+import com.mitchellbosecke.pebble.tokenParser.AbstractTokenParser;
+import com.mitchellbosecke.pebble.tokenParser.TokenParser;
+
+/**
+ * This tests tests the parallel parsing / compilation of templates.
+ *
+ * @author Thomas Hunziker
+ *
+ */
+public class TestParallelParsing extends AbstractTest {
+
+    /**
+     * Tests if the parse is working correctly within a multi threading
+     * environment.
+     *
+     * @throws InterruptedException
+     */
+    @Test
+    public void testParser() throws InterruptedException {
+
+        // Setup
+        pebble.addExtension(new DelayExtension());
+
+        final AtomicReference<String> resultThread1 = new AtomicReference<String>();
+        final AtomicReference<String> resultThread2 = new AtomicReference<String>();
+
+        Thread thread1 = new Thread(new Runnable() {
+
+            @Override
+            public void run() {
+                try {
+                    PebbleTemplate template = pebble.getTemplate("template.parallelParsing1.peb");
+                    Writer writer = new StringWriter();
+                    template.evaluate(writer);
+                    resultThread1.set(writer.toString());
+                } catch (PebbleException | IOException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        });
+
+        Thread thread2 = new Thread(new Runnable() {
+
+            @Override
+            public void run() {
+                try {
+                    PebbleTemplate template = pebble.getTemplate("template.parallelParsing2.peb");
+                    Writer writer = new StringWriter();
+                    template.evaluate(writer);
+                    resultThread2.set(writer.toString());
+                } catch (PebbleException | IOException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        });
+
+        // Start the threads.
+        thread1.start();
+        thread2.start();
+
+        // Wait until both threads completed.
+        thread1.join();
+        thread2.join();
+
+        assertEquals("output in 1: a|output in 1: b|output in 1: c", resultThread1.get());
+        assertEquals("output in 2: a|output in 2: b|output in 2: c", resultThread2.get());
+    }
+
+    /**
+     * This extension provides a token parser which does introduce a delay
+     * during the parser. This allows to provoke failing of the test when the
+     * parallel implementation is not ok.
+     */
+    private static class DelayExtension extends AbstractExtension {
+
+        @Override
+        public List<TokenParser> getTokenParsers() {
+            return Arrays.asList((TokenParser) new DelayTokenParser());
+        }
+
+    }
+
+    private static class DelayTokenParser extends AbstractTokenParser {
+
+        @Override
+        public String getTag() {
+            return "delay";
+        }
+
+        @Override
+        public RenderableNode parse(Token token) throws ParserException {
+
+            TokenStream stream = this.parser.getStream();
+
+            // skip over the 'delay' token
+            Token delayName = stream.next();
+
+            // expect a name or string for the new block
+            if (!delayName.test(Token.Type.NUMBER)) {
+
+                // we already know an error has occurred but let's just call the
+                // typical "expect" method so that we know a proper error
+                // message is given to user
+                stream.expect(Token.Type.NUMBER);
+            }
+
+            int delay = Integer.valueOf(delayName.getValue());
+
+            try {
+                // We sleep for the given number of milliseconds:
+                Thread.sleep(delay);
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+
+            // skip over the delay
+            stream.next();
+
+            stream.expect(Token.Type.EXECUTE_END);
+
+            return new RenderableNode() {
+
+                @Override
+                public void accept(NodeVisitor visitor) {
+                    visitor.visit(this);
+                }
+
+                @Override
+                public void render(PebbleTemplateImpl self, Writer writer, EvaluationContext context)
+                        throws PebbleException, IOException {
+                    // Do nothing.
+                }
+            };
+        }
+
+    }
+
+}

--- a/src/test/resources/templates/template.parallelParsing1.peb
+++ b/src/test/resources/templates/template.parallelParsing1.peb
@@ -1,0 +1,1 @@
+output in 1: a|{% delay 100 %}output in 1: b|{% delay 200 %}output in 1: c

--- a/src/test/resources/templates/template.parallelParsing2.peb
+++ b/src/test/resources/templates/template.parallelParsing2.peb
@@ -1,0 +1,1 @@
+output in 2: a|{% delay 50 %}output in 2: b|{% delay 100 %}output in 2: c


### PR DESCRIPTION
In this pull request I have add support for parsing templates in parallel. The semaphore is not required anymore.

To test my changes I have add a unit test which I run before I change anything and with removed semaphore. The test fails as expected. The test does now not fail anymore after my changes.

I had to add some breaking changes:
* The lexer is not configurable anymore. The configuration is now in the separate class 'Syntax'. The syntax is immutable to make sure the syntax is not changed in the middle of the parsing.
* The NodeVisitors are not thread safe. Hence I had to add the factory pattern. So the visitors are created for each template parsing. This makes the whole thing thread-safe. The real change is that the extensions now needs to provide NodeVisitorFactory objects instead of NodeVisitor objects.
* I create for each template parsing a new Lexer and Parser object. This should not have any performance impact since I refactor the handling of the Syntax, which compiles the regex.
* The TokenParser needs to pass the parser as argument.

I reviewed the rest of the code. It seems as these are the only changes which are required to make the whole thing thread-safe. I found some spots which eventually can cause problems, however they exists before and have no effect on the parsing. They have only an effect on the rendering (see the new TODOs). 

If you see any problem please advise me!
