### PR TITLE
Added index0 for Twig compatiliblity 

### DIFF
--- a/src/main/java/com/mitchellbosecke/pebble/node/ForNode.java
+++ b/src/main/java/com/mitchellbosecke/pebble/node/ForNode.java
@@ -92,8 +92,9 @@ public class ForNode extends AbstractRenderableNode {
                 loop.put("last", index == length - 1);
                 loop.put("first", index == 0);
                 loop.put("revindex", length - index - 1);
+                loop.put("revindex0", length - index - 1);
+                loop.put("index0", index);
                 loop.put("index", index++);
-                loop.put("length", length);
                 loop.put("length", length);
 
                 context.put("loop", loop);


### PR DESCRIPTION
Just to add some compatibility between pebble and twig:

Twig index is 1 based :/ The 0 based index is called index0
(historical issue)