### PR TITLE
#134 - Load resource bundles using UTF-8 encoding

### DIFF
--- a/src/main/java/com/mitchellbosecke/pebble/extension/i18n/UTF8Control.java
+++ b/src/main/java/com/mitchellbosecke/pebble/extension/i18n/UTF8Control.java
@@ -1,0 +1,43 @@
+package com.mitchellbosecke.pebble.extension.i18n;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.URL;
+import java.net.URLConnection;
+import java.util.Locale;
+import java.util.PropertyResourceBundle;
+import java.util.ResourceBundle;
+
+public class UTF8Control extends ResourceBundle.Control {
+
+    public ResourceBundle newBundle (String baseName, Locale locale, String format, ClassLoader loader, boolean reload)
+            throws IllegalAccessException, InstantiationException, IOException {
+
+        String bundleName = toBundleName(baseName, locale);
+        String resourceName = toResourceName(bundleName, "properties");
+        ResourceBundle bundle = null;
+        InputStream stream = null;
+        if (reload) {
+            URL url = loader.getResource(resourceName);
+            if (url != null) {
+                URLConnection connection = url.openConnection();
+                if (connection != null) {
+                    connection.setUseCaches(false);
+                    stream = connection.getInputStream();
+                }
+            }
+        } else {
+            stream = loader.getResourceAsStream(resourceName);
+        }
+
+        if (stream != null) {
+            try {
+                bundle = new PropertyResourceBundle(new InputStreamReader(stream, "UTF-8"));
+            } finally {
+                stream.close();
+            }
+        }
+        return bundle;
+    }
+}

--- a/src/main/java/com/mitchellbosecke/pebble/extension/i18n/i18nFunction.java
+++ b/src/main/java/com/mitchellbosecke/pebble/extension/i18n/i18nFunction.java
@@ -18,6 +18,8 @@ public class i18nFunction implements Function {
 
     private final List<String> argumentNames = new ArrayList<>();
 
+    private ResourceBundle.Control utf8Control = new UTF8Control();
+
     public i18nFunction() {
         argumentNames.add("bundle");
         argumentNames.add("key");
@@ -38,7 +40,7 @@ public class i18nFunction implements Function {
         EvaluationContext context = (EvaluationContext) args.get("_context");
         Locale locale = context.getLocale();
 
-        ResourceBundle bundle = ResourceBundle.getBundle(basename, locale);
+        ResourceBundle bundle = ResourceBundle.getBundle(basename, locale, utf8Control);
         Object phraseObject = bundle.getObject(key);
 
         if (phraseObject != null && params != null) {

--- a/src/test/java/com/mitchellbosecke/pebble/I18nExtensionTest.java
+++ b/src/test/java/com/mitchellbosecke/pebble/I18nExtensionTest.java
@@ -64,6 +64,19 @@ public class I18nExtensionTest extends AbstractTest {
 	}
 
 	@Test
+	public void testLookupSpecialChar() throws PebbleException, IOException {
+		Loader loader = new StringLoader();
+		PebbleEngine pebble = new PebbleEngine(loader);
+		pebble.addExtension(new I18nExtension());
+
+		PebbleTemplate template = pebble.getTemplate("{{ i18n('testMessages','greeting.specialchars') }}");
+
+		Writer writer = new StringWriter();
+		template.evaluate(writer, new Locale("es", "US"));
+		assertEquals("Hola español", writer.toString());
+	}
+
+	@Test
 	public void testMessageWithParams() throws PebbleException, IOException {
 		Loader loader = new StringLoader();
 		PebbleEngine pebble = new PebbleEngine(loader);

--- a/src/test/resources/testMessages_es_US.properties
+++ b/src/test/resources/testMessages_es_US.properties
@@ -1,2 +1,3 @@
 greeting=Hola
 greeting.someone=Hola, {0}
+greeting.specialchars=Hola español


### PR DESCRIPTION
instead of the default ISO-8859-1 use of UTF-8 should be always the default encoding.