### PR TITLE
Add better error handling within expression

### DIFF
--- a/src/main/java/com/mitchellbosecke/pebble/extension/escaper/EscaperNodeVisitor.java
+++ b/src/main/java/com/mitchellbosecke/pebble/extension/escaper/EscaperNodeVisitor.java
@@ -85,14 +85,14 @@ public class EscaperNodeVisitor extends AbstractNodeVisitor {
         List<NamedArgumentNode> namedArgs = new ArrayList<>();
         if (!strategies.isEmpty() && strategies.peek() != null) {
             String strategy = strategies.peek();
-            namedArgs.add(new NamedArgumentNode("strategy", new LiteralStringExpression(strategy)));
+            namedArgs.add(new NamedArgumentNode("strategy", new LiteralStringExpression(strategy, expression.getLineNumber())));
         }
-        ArgumentsNode args = new ArgumentsNode(null, namedArgs);
+        ArgumentsNode args = new ArgumentsNode(null, namedArgs, expression.getLineNumber());
 
         /*
          * Create the filter invocation with the newly created named arguments.
          */
-        FilterInvocationExpression filter = new FilterInvocationExpression("escape", args);
+        FilterInvocationExpression filter = new FilterInvocationExpression("escape", args, expression.getLineNumber());
 
         /*
          * The given expression and the filter invocation now become a binary

--- a/src/main/java/com/mitchellbosecke/pebble/node/ArgumentsNode.java
+++ b/src/main/java/com/mitchellbosecke/pebble/node/ArgumentsNode.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of Pebble.
- * 
+ *
  * Copyright (c) 2014 by Mitchell Bösecke
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  ******************************************************************************/
@@ -22,11 +22,14 @@ public class ArgumentsNode implements Node {
 
     private final List<NamedArgumentNode> namedArgs;
 
-    private List<PositionalArgumentNode> positionalArgs;
+    private final List<PositionalArgumentNode> positionalArgs;
 
-    public ArgumentsNode(List<PositionalArgumentNode> positionalArgs, List<NamedArgumentNode> namedArgs) {
+    private final int lineNumber;
+
+    public ArgumentsNode(List<PositionalArgumentNode> positionalArgs, List<NamedArgumentNode> namedArgs, int lineNumber) {
         this.positionalArgs = positionalArgs;
         this.namedArgs = namedArgs;
+        this.lineNumber = lineNumber;
     }
 
     @Override
@@ -46,7 +49,7 @@ public class ArgumentsNode implements Node {
      * Using hints from the filter/function/test/macro it will convert an
      * ArgumentMap (which holds both positional and named arguments) into a
      * regular Map that the filter/function/test/macro is expecting.
-     * 
+     *
      * @param self
      *            The template implementation
      * @param context
@@ -76,6 +79,12 @@ public class ArgumentsNode implements Node {
                 int nameIndex = 0;
 
                 for (PositionalArgumentNode arg : positionalArgs) {
+                    if (argumentNames.size() <= nameIndex) {
+                        throw new PebbleException(null, "The argument at position " + (nameIndex + 1)
+                                + " is not allowed. Only " + argumentNames.size() + " argument(s) are allowed.",
+                                this.lineNumber, self.getName());
+                    }
+
                     result.put(argumentNames.get(nameIndex), arg.getValueExpression().evaluate(self, context));
                     nameIndex++;
                 }
@@ -85,7 +94,8 @@ public class ArgumentsNode implements Node {
                 for (NamedArgumentNode arg : namedArgs) {
                     // check if user used an incorrect name
                     if (!argumentNames.contains(arg.getName())) {
-                        throw new PebbleException(null, "The following named argument does not exist: " + arg.getName());
+                        throw new PebbleException(null, "The following named argument does not exist: " + arg.getName(),
+                                this.lineNumber, self.getName());
                     }
                     Object value = arg.getValueExpression() == null ? null : arg.getValueExpression().evaluate(self,
                             context);

--- a/src/main/java/com/mitchellbosecke/pebble/node/FunctionOrMacroNameNode.java
+++ b/src/main/java/com/mitchellbosecke/pebble/node/FunctionOrMacroNameNode.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of Pebble.
- * 
+ *
  * Copyright (c) 2014 by Mitchell Bösecke
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  ******************************************************************************/
@@ -18,8 +18,11 @@ public class FunctionOrMacroNameNode implements Expression<String> {
 
     private final String name;
 
-    public FunctionOrMacroNameNode(String name) {
+    private final int lineNumber;
+
+    public FunctionOrMacroNameNode(String name, int lineNumber) {
         this.name = name;
+        this.lineNumber = lineNumber;
     }
 
     @Override
@@ -34,6 +37,11 @@ public class FunctionOrMacroNameNode implements Expression<String> {
 
     public String getName() {
         return name;
+    }
+
+    @Override
+    public int getLineNumber() {
+        return this.lineNumber;
     }
 
 }

--- a/src/main/java/com/mitchellbosecke/pebble/node/TestInvocationExpression.java
+++ b/src/main/java/com/mitchellbosecke/pebble/node/TestInvocationExpression.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of Pebble.
- * 
+ *
  * Copyright (c) 2014 by Mitchell Bösecke
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  ******************************************************************************/
@@ -16,15 +16,17 @@ import com.mitchellbosecke.pebble.template.PebbleTemplateImpl;
 
 /**
  * The right hand side to the test expression.
- * 
+ *
  * @author Mitchell
- * 
+ *
  */
 public class TestInvocationExpression implements Expression<Object> {
 
     private final String testName;
 
     private final ArgumentsNode args;
+
+    private final int lineNumber;
 
     @Override
     public Object evaluate(PebbleTemplateImpl self, EvaluationContext context) throws PebbleException {
@@ -34,6 +36,7 @@ public class TestInvocationExpression implements Expression<Object> {
     public TestInvocationExpression(int lineNumber, String testName, ArgumentsNode args) {
         this.testName = testName;
         this.args = args;
+        this.lineNumber = lineNumber;
     }
 
     @Override
@@ -49,4 +52,8 @@ public class TestInvocationExpression implements Expression<Object> {
         return testName;
     }
 
+    @Override
+    public int getLineNumber() {
+        return this.lineNumber;
+    }
 }

--- a/src/main/java/com/mitchellbosecke/pebble/node/expression/ArrayExpression.java
+++ b/src/main/java/com/mitchellbosecke/pebble/node/expression/ArrayExpression.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of Pebble.
- * 
+ *
  * Copyright (c) 2014 by Mitchell Bösecke
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  ******************************************************************************/
@@ -20,17 +20,20 @@ import com.mitchellbosecke.pebble.template.PebbleTemplateImpl;
 public class ArrayExpression implements Expression<List<?>> {
 
     private final List<Expression<?>> values;
+    private final int lineNumber;
 
-    public ArrayExpression() {
+    public ArrayExpression(int lineNumber) {
         this.values = Collections.emptyList();
+        this.lineNumber = lineNumber;
     }
 
-    public ArrayExpression(List<Expression<?>> values) {
+    public ArrayExpression(List<Expression<?>> values, int lineNumber) {
         if (values == null) {
             this.values = Collections.emptyList();
         } else {
             this.values = values;
         }
+        this.lineNumber = lineNumber;
     }
 
     @Override
@@ -47,6 +50,11 @@ public class ArrayExpression implements Expression<List<?>> {
             returnValues.add(value);
         }
         return returnValues;
+    }
+
+    @Override
+    public int getLineNumber() {
+        return this.lineNumber;
     }
 
 }

--- a/src/main/java/com/mitchellbosecke/pebble/node/expression/BinaryExpression.java
+++ b/src/main/java/com/mitchellbosecke/pebble/node/expression/BinaryExpression.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of Pebble.
- * 
+ *
  * Copyright (c) 2014 by Mitchell Bösecke
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  ******************************************************************************/
@@ -11,9 +11,11 @@ package com.mitchellbosecke.pebble.node.expression;
 import com.mitchellbosecke.pebble.extension.NodeVisitor;
 
 public abstract class BinaryExpression<T> implements Expression<T> {
-    
-    public BinaryExpression(){
-        
+
+    private int lineNumber;
+
+    public BinaryExpression() {
+
     }
 
     private Expression<?> leftExpression;
@@ -39,6 +41,21 @@ public abstract class BinaryExpression<T> implements Expression<T> {
     @Override
     public void accept(NodeVisitor visitor) {
         visitor.visit(this);
+    }
+
+    /**
+     * Sets the line number on which the expression is defined on.
+     *
+     * @param lineNumber
+     *            the line number on which the expression is defined on.
+     */
+    public void setLineNumber(int lineNumber) {
+        this.lineNumber = lineNumber;
+    }
+
+    @Override
+    public int getLineNumber() {
+        return this.lineNumber;
     }
 
 }

--- a/src/main/java/com/mitchellbosecke/pebble/node/expression/BlockFunctionExpression.java
+++ b/src/main/java/com/mitchellbosecke/pebble/node/expression/BlockFunctionExpression.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of Pebble.
- * 
+ *
  * Copyright (c) 2014 by Mitchell Bösecke
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  ******************************************************************************/
@@ -22,8 +22,11 @@ public class BlockFunctionExpression implements Expression<String> {
 
     private final Expression<?> blockNameExpression;
 
-    public BlockFunctionExpression(ArgumentsNode args) {
+    private final int lineNumber;
+
+    public BlockFunctionExpression(ArgumentsNode args, int lineNumber) {
         this.blockNameExpression = args.getPositionalArgs().get(0).getValueExpression();
+        this.lineNumber = lineNumber;
     }
 
     @Override
@@ -33,7 +36,7 @@ public class BlockFunctionExpression implements Expression<String> {
         try {
             self.block(writer, context, blockName, false);
         } catch (IOException e) {
-            throw new PebbleException(e, "Could not render block [" + blockName + "]");
+            throw new PebbleException(e, "Could not render block [" + blockName + "]", this.getLineNumber(), self.getName());
         }
         return writer.toString();
     }
@@ -41,6 +44,11 @@ public class BlockFunctionExpression implements Expression<String> {
     @Override
     public void accept(NodeVisitor visitor) {
         visitor.visit(this);
+    }
+
+    @Override
+    public int getLineNumber() {
+        return this.lineNumber;
     }
 
 }

--- a/src/main/java/com/mitchellbosecke/pebble/node/expression/ContextVariableExpression.java
+++ b/src/main/java/com/mitchellbosecke/pebble/node/expression/ContextVariableExpression.java
@@ -20,12 +20,9 @@ public class ContextVariableExpression implements Expression<Object> {
 
     private final int lineNumber;
 
-    private final String filename;
-
-    public ContextVariableExpression(String name, int lineNumber, String filename) {
+    public ContextVariableExpression(String name, int lineNumber) {
         this.name = name;
         this.lineNumber = lineNumber;
-        this.filename = filename;
     }
 
     @Override
@@ -43,27 +40,14 @@ public class ContextVariableExpression implements Expression<Object> {
         if (context.isStrictVariables() && result == null && !context.containsKey(name)) {
             throw new RootAttributeNotFoundException(null, String.format(
                     "Root attribute [%s] does not exist or can not be accessed and strict variables is set to true.",
-                    this.name), this.name, this.lineNumber, this.filename);
+                    this.name), this.name, this.lineNumber, self.getName());
         }
         return result;
     }
 
-    /**
-     * Returns the line number on which the expression is defined on.
-     *
-     * @return the line number on which the expression is defined on.
-     */
+   @Override
     public int getLineNumber() {
         return lineNumber;
-    }
-
-    /**
-     * Returns the filename in which the expression is defined in.
-     *
-     * @return the filename in which the expression is defined in.
-     */
-    public String getFilename() {
-        return filename;
     }
 
 }

--- a/src/main/java/com/mitchellbosecke/pebble/node/expression/Expression.java
+++ b/src/main/java/com/mitchellbosecke/pebble/node/expression/Expression.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of Pebble.
- * 
+ *
  * Copyright (c) 2014 by Mitchell Bösecke
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  ******************************************************************************/
@@ -16,4 +16,11 @@ import com.mitchellbosecke.pebble.template.PebbleTemplateImpl;
 public interface Expression<T> extends Node {
 
     T evaluate(PebbleTemplateImpl self, EvaluationContext context) throws PebbleException;
+
+    /**
+     * Returns the line number on which the expression is defined on.
+     *
+     * @return the line number on which the expression is defined on.
+     */
+    int getLineNumber();
 }

--- a/src/main/java/com/mitchellbosecke/pebble/node/expression/FilterExpression.java
+++ b/src/main/java/com/mitchellbosecke/pebble/node/expression/FilterExpression.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of Pebble.
- * 
+ *
  * Copyright (c) 2014 by Mitchell Bösecke
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  ******************************************************************************/
@@ -42,7 +42,7 @@ public class FilterExpression extends BinaryExpression<Object> {
         }
 
         if (filter == null) {
-            throw new PebbleException(null, String.format("Filter [%s] does not exist.", filterName));
+            throw new PebbleException(null, String.format("Filter [%s] does not exist.", filterName), this.getLineNumber(), self.getName());
         }
 
         if (filter instanceof LocaleAware) {

--- a/src/main/java/com/mitchellbosecke/pebble/node/expression/FilterInvocationExpression.java
+++ b/src/main/java/com/mitchellbosecke/pebble/node/expression/FilterInvocationExpression.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of Pebble.
- * 
+ *
  * Copyright (c) 2014 by Mitchell Bösecke
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  ******************************************************************************/
@@ -16,9 +16,9 @@ import com.mitchellbosecke.pebble.template.PebbleTemplateImpl;
 
 /**
  * The right hand side to the filter expression.
- * 
+ *
  * @author Mitchell
- * 
+ *
  */
 public class FilterInvocationExpression implements Expression<Object> {
 
@@ -26,9 +26,12 @@ public class FilterInvocationExpression implements Expression<Object> {
 
     private final ArgumentsNode args;
 
-    public FilterInvocationExpression(String filterName, ArgumentsNode args) {
+    private final int lineNumber;
+
+    public FilterInvocationExpression(String filterName, ArgumentsNode args, int lineNumber) {
         this.filterName = filterName;
         this.args = args;
+        this.lineNumber = lineNumber;
     }
 
     @Override
@@ -46,6 +49,11 @@ public class FilterInvocationExpression implements Expression<Object> {
 
     public String getFilterName() {
         return filterName;
+    }
+
+    @Override
+    public int getLineNumber() {
+        return this.lineNumber;
     }
 
 }

--- a/src/main/java/com/mitchellbosecke/pebble/node/expression/FunctionOrMacroInvocationExpression.java
+++ b/src/main/java/com/mitchellbosecke/pebble/node/expression/FunctionOrMacroInvocationExpression.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of Pebble.
- * 
+ *
  * Copyright (c) 2014 by Mitchell Bösecke
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  ******************************************************************************/
@@ -27,9 +27,12 @@ public class FunctionOrMacroInvocationExpression implements Expression<Object> {
 
     private final ArgumentsNode args;
 
-    public FunctionOrMacroInvocationExpression(String functionName, ArgumentsNode arguments) {
+    private final int lineNumber;
+
+    public FunctionOrMacroInvocationExpression(String functionName, ArgumentsNode arguments, int lineNumber) {
         this.functionName = functionName;
         this.args = arguments;
+        this.lineNumber = lineNumber;
     }
 
     @Override
@@ -66,6 +69,11 @@ public class FunctionOrMacroInvocationExpression implements Expression<Object> {
 
     public ArgumentsNode getArguments() {
         return args;
+    }
+
+    @Override
+    public int getLineNumber() {
+        return this.lineNumber;
     }
 
 }

--- a/src/main/java/com/mitchellbosecke/pebble/node/expression/GetAttributeExpression.java
+++ b/src/main/java/com/mitchellbosecke/pebble/node/expression/GetAttributeExpression.java
@@ -15,11 +15,11 @@
 package com.mitchellbosecke.pebble.node.expression;
 
 import java.lang.reflect.AccessibleObject;
+import java.lang.reflect.Array;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Member;
 import java.lang.reflect.Method;
-import java.lang.reflect.Array;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -58,11 +58,13 @@ public class GetAttributeExpression implements Expression<Object> {
      */
     private final ConcurrentHashMap<Class<?>, Member> memberCache;
 
-    public GetAttributeExpression(Expression<?> node, Expression<?> attributeNameExpression, String filename, int lineNumber) {
+    public GetAttributeExpression(Expression<?> node, Expression<?> attributeNameExpression, String filename,
+            int lineNumber) {
         this(node, attributeNameExpression, null, filename, lineNumber);
     }
 
-    public GetAttributeExpression(Expression<?> node, Expression<?> attributeNameExpression, ArgumentsNode args, String filename, int lineNumber) {
+    public GetAttributeExpression(Expression<?> node, Expression<?> attributeNameExpression, ArgumentsNode args,
+            String filename, int lineNumber) {
 
         this.node = node;
         this.attributeNameExpression = attributeNameExpression;
@@ -348,6 +350,11 @@ public class GetAttributeExpression implements Expression<Object> {
 
     public ArgumentsNode getArgumentsNode() {
         return args;
+    }
+
+    @Override
+    public int getLineNumber() {
+        return this.lineNumber;
     }
 
 }

--- a/src/main/java/com/mitchellbosecke/pebble/node/expression/LiteralBooleanExpression.java
+++ b/src/main/java/com/mitchellbosecke/pebble/node/expression/LiteralBooleanExpression.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of Pebble.
- * 
+ *
  * Copyright (c) 2014 by Mitchell Bösecke
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  ******************************************************************************/
@@ -17,8 +17,11 @@ public class LiteralBooleanExpression implements Expression<Boolean> {
 
     private final Boolean value;
 
-    public LiteralBooleanExpression(Boolean value) {
+    private final int lineNumber;
+
+    public LiteralBooleanExpression(Boolean value, int lineNumber) {
         this.value = value;
+        this.lineNumber = lineNumber;
     }
 
     @Override
@@ -29,6 +32,11 @@ public class LiteralBooleanExpression implements Expression<Boolean> {
     @Override
     public Boolean evaluate(PebbleTemplateImpl self, EvaluationContext context) throws PebbleException {
         return value;
+    }
+
+    @Override
+    public int getLineNumber() {
+        return this.lineNumber;
     }
 
 }

--- a/src/main/java/com/mitchellbosecke/pebble/node/expression/LiteralDoubleExpression.java
+++ b/src/main/java/com/mitchellbosecke/pebble/node/expression/LiteralDoubleExpression.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of Pebble.
- * 
+ *
  * Copyright (c) 2014 by Mitchell Bösecke
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  ******************************************************************************/
@@ -17,8 +17,11 @@ public class LiteralDoubleExpression implements Expression<Double> {
 
     private final Double value;
 
-    public LiteralDoubleExpression(Double value) {
+    private final int lineNumber;
+
+    public LiteralDoubleExpression(Double value, int lineNumber) {
         this.value = value;
+        this.lineNumber = lineNumber;
     }
 
     @Override
@@ -29,6 +32,11 @@ public class LiteralDoubleExpression implements Expression<Double> {
     @Override
     public Double evaluate(PebbleTemplateImpl self, EvaluationContext context) throws PebbleException {
         return value;
+    }
+
+    @Override
+    public int getLineNumber() {
+        return this.lineNumber;
     }
 
 }

--- a/src/main/java/com/mitchellbosecke/pebble/node/expression/LiteralLongExpression.java
+++ b/src/main/java/com/mitchellbosecke/pebble/node/expression/LiteralLongExpression.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of Pebble.
- * 
+ *
  * Copyright (c) 2014 by Mitchell Bösecke
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  ******************************************************************************/
@@ -16,9 +16,11 @@ import com.mitchellbosecke.pebble.template.PebbleTemplateImpl;
 public class LiteralLongExpression implements Expression<Long> {
 
     private final Long value;
+    private final int lineNumber;
 
-    public LiteralLongExpression(Long value) {
+    public LiteralLongExpression(Long value, int lineNumber) {
         this.value = value;
+        this.lineNumber = lineNumber;
     }
 
     @Override
@@ -29,6 +31,11 @@ public class LiteralLongExpression implements Expression<Long> {
     @Override
     public Long evaluate(PebbleTemplateImpl self, EvaluationContext context) throws PebbleException {
         return value;
+    }
+
+    @Override
+    public int getLineNumber() {
+        return this.lineNumber;
     }
 
 }

--- a/src/main/java/com/mitchellbosecke/pebble/node/expression/LiteralNullExpression.java
+++ b/src/main/java/com/mitchellbosecke/pebble/node/expression/LiteralNullExpression.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of Pebble.
- * 
+ *
  * Copyright (c) 2014 by Mitchell Bösecke
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  ******************************************************************************/
@@ -15,6 +15,12 @@ import com.mitchellbosecke.pebble.template.PebbleTemplateImpl;
 
 public class LiteralNullExpression implements Expression<Object> {
 
+    private final int lineNumber;
+
+    public LiteralNullExpression(int lineNumber) {
+        this.lineNumber = lineNumber;
+    }
+
     @Override
     public void accept(NodeVisitor visitor) {
         visitor.visit(this);
@@ -23,6 +29,11 @@ public class LiteralNullExpression implements Expression<Object> {
     @Override
     public Object evaluate(PebbleTemplateImpl self, EvaluationContext context) throws PebbleException {
         return null;
+    }
+
+    @Override
+    public int getLineNumber() {
+        return this.lineNumber;
     }
 
 }

--- a/src/main/java/com/mitchellbosecke/pebble/node/expression/LiteralStringExpression.java
+++ b/src/main/java/com/mitchellbosecke/pebble/node/expression/LiteralStringExpression.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of Pebble.
- * 
+ *
  * Copyright (c) 2014 by Mitchell Bösecke
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  ******************************************************************************/
@@ -17,8 +17,11 @@ public class LiteralStringExpression implements Expression<String> {
 
     private final String value;
 
-    public LiteralStringExpression(String value) {
+    private final int lineNumber;
+
+    public LiteralStringExpression(String value, int lineNumber) {
         this.value = value;
+        this.lineNumber = lineNumber;
     }
 
     @Override
@@ -29,6 +32,11 @@ public class LiteralStringExpression implements Expression<String> {
     @Override
     public String evaluate(PebbleTemplateImpl self, EvaluationContext context) throws PebbleException {
         return value;
+    }
+
+    @Override
+    public int getLineNumber() {
+        return this.lineNumber;
     }
 
 }

--- a/src/main/java/com/mitchellbosecke/pebble/node/expression/MapExpression.java
+++ b/src/main/java/com/mitchellbosecke/pebble/node/expression/MapExpression.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of Pebble.
- * 
+ *
  * Copyright (c) 2014 by Mitchell Bösecke
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  ******************************************************************************/
@@ -22,17 +22,20 @@ public class MapExpression implements Expression<Map<?, ?>> {
 
     // FIXME should keys be of any type?
     private final Map<Expression<?>, Expression<?>> entries;
+    private final int lineNumber;
 
-    public MapExpression() {
+    public MapExpression(int lineNumber) {
         this.entries = Collections.emptyMap();
+        this.lineNumber = lineNumber;
     }
 
-    public MapExpression(Map<Expression<?>, Expression<?>> entries) {
+    public MapExpression(Map<Expression<?>, Expression<?>> entries, int lineNumber) {
         if (entries == null) {
             this.entries = Collections.emptyMap();
         } else {
             this.entries = entries;
         }
+        this.lineNumber = lineNumber;
     }
 
     @Override
@@ -52,6 +55,11 @@ public class MapExpression implements Expression<Map<?, ?>> {
             returnEntries.put(key, value);
         }
         return returnEntries;
+    }
+
+    @Override
+    public int getLineNumber() {
+        return this.lineNumber;
     }
 
 }

--- a/src/main/java/com/mitchellbosecke/pebble/node/expression/ParentFunctionExpression.java
+++ b/src/main/java/com/mitchellbosecke/pebble/node/expression/ParentFunctionExpression.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of Pebble.
- * 
+ *
  * Copyright (c) 2014 by Mitchell Bösecke
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  ******************************************************************************/
@@ -38,12 +38,13 @@ public class ParentFunctionExpression implements Expression<String> {
                         self.getName());
             }
             PebbleTemplateImpl parent = context.getParentTemplate();
-            
+
             context.ascendInheritanceChain();
             parent.block(writer, context, blockName, true);
             context.descendInheritanceChain();
         } catch (IOException e) {
-            throw new PebbleException(e, "Could not render block [" + blockName + "]");
+            throw new PebbleException(e, "Could not render block [" + blockName + "]", this.getLineNumber(),
+                    self.getName());
         }
         return writer.toString();
     }
@@ -51,6 +52,11 @@ public class ParentFunctionExpression implements Expression<String> {
     @Override
     public void accept(NodeVisitor visitor) {
         visitor.visit(this);
+    }
+
+    @Override
+    public int getLineNumber() {
+        return this.lineNumber;
     }
 
 }

--- a/src/main/java/com/mitchellbosecke/pebble/node/expression/PositiveTestExpression.java
+++ b/src/main/java/com/mitchellbosecke/pebble/node/expression/PositiveTestExpression.java
@@ -37,7 +37,8 @@ public class PositiveTestExpression extends BinaryExpression<Object> {
             cachedTest = tests.get(testInvocation.getTestName());
 
             if (cachedTest == null) {
-                throw new PebbleException(null, String.format("Test [%s] does not exist.", testName));
+                throw new PebbleException(null, String.format("Test [%s] does not exist.", testName),
+                        this.getLineNumber(), self.getName());
             }
 
             if (cachedTest instanceof LocaleAware) {

--- a/src/main/java/com/mitchellbosecke/pebble/node/expression/RangeExpression.java
+++ b/src/main/java/com/mitchellbosecke/pebble/node/expression/RangeExpression.java
@@ -24,9 +24,9 @@ public class RangeExpression extends BinaryExpression<Object> {
         positionalArgs.add(new PositionalArgumentNode(getLeftExpression()));
         positionalArgs.add(new PositionalArgumentNode(getRightExpression()));
 
-        ArgumentsNode arguments = new ArgumentsNode(positionalArgs, null);
+        ArgumentsNode arguments = new ArgumentsNode(positionalArgs, null, this.getLineNumber());
         FunctionOrMacroInvocationExpression function = new FunctionOrMacroInvocationExpression(
-                RangeFunction.FUNCTION_NAME, arguments);
+                RangeFunction.FUNCTION_NAME, arguments, this.getLineNumber());
 
         return function.evaluate(self, context);
     }

--- a/src/main/java/com/mitchellbosecke/pebble/node/expression/RenderableNodeExpression.java
+++ b/src/main/java/com/mitchellbosecke/pebble/node/expression/RenderableNodeExpression.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of Pebble.
- * 
+ *
  * Copyright (c) 2014 by Mitchell Bösecke
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  ******************************************************************************/
@@ -21,7 +21,7 @@ import com.mitchellbosecke.pebble.template.PebbleTemplateImpl;
  * This class wraps a {@link RenderableNode} into an expression. This is used by
  * the filter TAG to apply a filter to large chunk of template which is
  * contained within a renderable node.
- * 
+ *
  * @author mbosecke
  *
  */
@@ -29,8 +29,11 @@ public class RenderableNodeExpression extends UnaryExpression {
 
     private final RenderableNode node;
 
-    public RenderableNodeExpression(RenderableNode node) {
+    private final int lineNumber;
+
+    public RenderableNodeExpression(RenderableNode node, int lineNumber) {
         this.node = node;
+        this.lineNumber = lineNumber;
     }
 
     @Override
@@ -39,9 +42,14 @@ public class RenderableNodeExpression extends UnaryExpression {
         try {
             node.render(self, writer, context);
         } catch (IOException e) {
-            throw new PebbleException(e, "Error occurred while rendering node");
+            throw new PebbleException(e, "Error occurred while rendering node", this.getLineNumber(), self.getName());
         }
         return writer.toString();
+    }
+
+    @Override
+    public int getLineNumber() {
+        return this.lineNumber;
     }
 
 }

--- a/src/main/java/com/mitchellbosecke/pebble/node/expression/TernaryExpression.java
+++ b/src/main/java/com/mitchellbosecke/pebble/node/expression/TernaryExpression.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of Pebble.
- * 
+ *
  * Copyright (c) 2014 by Mitchell Bösecke
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  ******************************************************************************/
@@ -21,10 +21,13 @@ public class TernaryExpression implements Expression<Object> {
 
     private Expression<?> expression3;
 
-    public TernaryExpression(Expression<Boolean> expression1, Expression<?> expression2, Expression<?> expression3) {
+    private final int lineNumber;
+
+    public TernaryExpression(Expression<Boolean> expression1, Expression<?> expression2, Expression<?> expression3, int lineNumber, String filename) {
         this.expression1 = expression1;
         this.expression2 = expression2;
         this.expression3 = expression3;
+        this.lineNumber = lineNumber;
     }
 
     @Override
@@ -61,4 +64,8 @@ public class TernaryExpression implements Expression<Object> {
         this.expression2 = expression2;
     }
 
+    @Override
+    public int getLineNumber() {
+       return this.lineNumber;
+    }
 }

--- a/src/main/java/com/mitchellbosecke/pebble/node/expression/UnaryExpression.java
+++ b/src/main/java/com/mitchellbosecke/pebble/node/expression/UnaryExpression.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of Pebble.
- * 
+ *
  * Copyright (c) 2014 by Mitchell Bösecke
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  ******************************************************************************/
@@ -13,6 +13,8 @@ import com.mitchellbosecke.pebble.extension.NodeVisitor;
 public abstract class UnaryExpression implements Expression<Object> {
 
     private Expression<?> childExpression;
+
+    private int lineNumber;
 
     @Override
     public void accept(NodeVisitor visitor) {
@@ -26,5 +28,22 @@ public abstract class UnaryExpression implements Expression<Object> {
     public void setChildExpression(Expression<?> childExpression) {
         this.childExpression = childExpression;
     }
+
+
+    /**
+     * Sets the line number on which the expression is defined on.
+     *
+     * @param lineNumber
+     *            the line number on which the expression is defined on.
+     */
+    public void setLineNumber(int lineNumber) {
+        this.lineNumber = lineNumber;
+    }
+
+    @Override
+    public int getLineNumber() {
+        return this.lineNumber;
+    }
+
 
 }

--- a/src/main/java/com/mitchellbosecke/pebble/tokenParser/FilterTokenParser.java
+++ b/src/main/java/com/mitchellbosecke/pebble/tokenParser/FilterTokenParser.java
@@ -55,7 +55,7 @@ public class FilterTokenParser extends AbstractTokenParser {
         stream.next();
         stream.expect(Token.Type.EXECUTE_END);
 
-        Expression<?> lastExpression = new RenderableNodeExpression(body);
+        Expression<?> lastExpression = new RenderableNodeExpression(body, stream.current().getLineNumber());
 
         for(Expression<?> filterInvocationExpression : filterInvocationExpressions){
 

--- a/src/test/java/com/mitchellbosecke/pebble/ArgumentsNodeTest.java
+++ b/src/test/java/com/mitchellbosecke/pebble/ArgumentsNodeTest.java
@@ -1,0 +1,45 @@
+package com.mitchellbosecke.pebble;
+
+import java.io.StringWriter;
+import java.io.Writer;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.mitchellbosecke.pebble.error.PebbleException;
+import com.mitchellbosecke.pebble.loader.Loader;
+import com.mitchellbosecke.pebble.loader.StringLoader;
+import com.mitchellbosecke.pebble.node.ArgumentsNode;
+import com.mitchellbosecke.pebble.template.PebbleTemplate;
+
+/**
+ * Tests {@link ArgumentsNode}.
+ */
+public class ArgumentsNodeTest extends AbstractTest{
+
+    /**
+     * Tests that the error description is clear when a invalid number of arguments are provided.
+     * @throws Exception
+     */
+    @Test
+    public void testInvalidArgument() throws Exception {
+
+        try {
+            Loader<?> loader = new StringLoader();
+            PebbleEngine pebble = new PebbleEngine(loader);
+
+            PebbleTemplate template = pebble
+                    .getTemplate("{{ 'This is a test of the abbreviate filter' | abbreviate(16, 10) }}");
+            Writer writer = new StringWriter();
+            template.evaluate(writer);
+            Assert.fail("Should not be reached, because an exception is expected.");
+        }
+        catch(PebbleException e) {
+            Assert.assertEquals("{{ 'This is a test of the abbreviate filter' | abbreviate(16, 10) }}", e.getFileName());
+            Assert.assertEquals(1, e.getLineNumber());
+        }
+
+    }
+
+
+}


### PR DESCRIPTION
I have add a method for getting the line number on the expression interface.

This helps to pass the line number along the exceptions. One thing which I do not like is the way I had to handle BinaryExpression and UnaryExpression. Since we are using reflections to create new instances we can not pass along the line number in the constructor. Eventually we should apply here the factory pattern. Instead we pass the class name in BinaryOperatorImpl resp. UnaryOperatorImpl we can pass a factory object. This factory object has a method to create new instances of the expressions. We could also pass easily the line number along the factory.

@mbosecke if you like to go the way with the factory I can change this. However the change with the factory would be an even bigger change. I would need to change essentially all expressions to also provide a factory class. In theory the implementation would be better since the line number can be final and we do not need reflections which is typically harder to understand for new developers.