### PR TITLE
Fix for bean method with Null Arguments 

### DIFF
--- a/src/main/java/com/mitchellbosecke/pebble/node/expression/GetAttributeExpression.java
+++ b/src/main/java/com/mitchellbosecke/pebble/node/expression/GetAttributeExpression.java
@@ -151,7 +151,13 @@ public class GetAttributeExpression implements Expression<Object> {
             Class<?>[] argumentTypes = new Class<?>[argumentValues.length];
 
             for (int i = 0; i < argumentValues.length; i++) {
-                argumentTypes[i] = argumentValues[i].getClass();
+                Object o = argumentValues[i];
+                if (o == null) {
+                    argumentTypes[i] = null;
+                }
+                else {
+                    argumentTypes[i] = o.getClass();
+                }
             }
 
             member = reflect(object, attributeName, argumentTypes);
@@ -312,7 +318,7 @@ public class GetAttributeExpression implements Expression<Object> {
 
             boolean compatibleTypes = true;
             for (int i = 0; i < types.length; i++) {
-                if (!widen(types[i]).isAssignableFrom(requiredTypes[i])) {
+                if (requiredTypes[i] != null && !widen(types[i]).isAssignableFrom(requiredTypes[i])) {
                     compatibleTypes = false;
                     break;
                 }

--- a/src/test/java/com/mitchellbosecke/pebble/GetAttributeTest.java
+++ b/src/test/java/com/mitchellbosecke/pebble/GetAttributeTest.java
@@ -528,6 +528,20 @@ public class GetAttributeTest extends AbstractTest {
 
         assertEquals("1 1 2", writer.toString());
     }
+    
+    @Test
+    public void testBeanMethodWithNullArgument() throws PebbleException, IOException {
+        PebbleEngine pebble = new PebbleEngine.Builder().loader(new StringLoader()).strictVariables(true).build();
+
+        PebbleTemplate template = pebble.getTemplate("hello {{ object.name(var) }}");
+        Map<String, Object> context = new HashMap<>();
+        context.put("object", new BeanWithMethodsThatHaveArguments());
+        context.put("var", null);
+
+        Writer writer = new StringWriter();
+        template.evaluate(writer, context);
+        assertEquals("hello ", writer.toString());
+    }
 
     public class PrimitiveArguments {
 


### PR DESCRIPTION
When passing null as an argument, a NullPointerException is thrown. This
PR fixes it