### PR TITLE
Escape functions by default

### DIFF
--- a/src/main/java/com/mitchellbosecke/pebble/PebbleEngine.java
+++ b/src/main/java/com/mitchellbosecke/pebble/PebbleEngine.java
@@ -408,17 +408,6 @@ public class PebbleEngine {
         }
 
         /**
-         * Marks a particular tag as safe to the built-in escaper extension.
-         *
-         * @param filter The name of the tag to be marked as safe
-         * @return This builder object
-         */
-        public Builder addEscaperSafeFilter(String filter) {
-            escaperExtension.addSafeFilter(filter);
-            return this;
-        }
-
-        /**
          * Adds an escaping strategy to the built-in escaper extension.
          *
          * @param name     The name of the escaping strategy

--- a/src/main/java/com/mitchellbosecke/pebble/extension/core/CapitalizeFilter.java
+++ b/src/main/java/com/mitchellbosecke/pebble/extension/core/CapitalizeFilter.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.Map;
 
 import com.mitchellbosecke.pebble.extension.Filter;
+import com.mitchellbosecke.pebble.extension.escaper.RawString;
 
 public class CapitalizeFilter implements Filter {
 
@@ -26,7 +27,7 @@ public class CapitalizeFilter implements Filter {
         if (input == null) {
             return null;
         }
-        String value = (String) input;
+        String value = input instanceof RawString ? input.toString() : (String) input;
 
         if (value.length() == 0) {
             return value;

--- a/src/main/java/com/mitchellbosecke/pebble/extension/core/DateFilter.java
+++ b/src/main/java/com/mitchellbosecke/pebble/extension/core/DateFilter.java
@@ -18,6 +18,7 @@ import java.util.Locale;
 import java.util.Map;
 
 import com.mitchellbosecke.pebble.extension.Filter;
+import com.mitchellbosecke.pebble.extension.escaper.RawString;
 import com.mitchellbosecke.pebble.template.EvaluationContext;
 
 public class DateFilter implements Filter {
@@ -60,6 +61,6 @@ public class DateFilter implements Filter {
             date = (Date) input;
         }
 
-        return intendedFormat.format(date);
+        return new RawString(intendedFormat.format(date));
     }
 }

--- a/src/main/java/com/mitchellbosecke/pebble/extension/core/LengthFilter.java
+++ b/src/main/java/com/mitchellbosecke/pebble/extension/core/LengthFilter.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Map;
 
 import com.mitchellbosecke.pebble.extension.Filter;
+import com.mitchellbosecke.pebble.extension.escaper.RawString;
 
 public class LengthFilter implements Filter {
 
@@ -20,8 +21,9 @@ public class LengthFilter implements Filter {
         if (input == null) {
             return 0;
         }
-
-        if (input instanceof String) {
+        if (input instanceof RawString) {
+            return input.toString().length();
+        } else if (input instanceof String) {
             return ((String) input).length();
         } else if (input instanceof Collection) {
             return ((Collection<?>) input).size();

--- a/src/main/java/com/mitchellbosecke/pebble/extension/core/LowerFilter.java
+++ b/src/main/java/com/mitchellbosecke/pebble/extension/core/LowerFilter.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.Map;
 
 import com.mitchellbosecke.pebble.extension.Filter;
+import com.mitchellbosecke.pebble.extension.escaper.RawString;
 
 public class LowerFilter implements Filter {
 
@@ -25,7 +26,8 @@ public class LowerFilter implements Filter {
         if (input == null) {
             return null;
         }
-        return ((String) input).toLowerCase();
+        String str = input instanceof RawString ? input.toString() : (String) input;
+        return str.toLowerCase();
     }
 
 }

--- a/src/main/java/com/mitchellbosecke/pebble/extension/core/TitleFilter.java
+++ b/src/main/java/com/mitchellbosecke/pebble/extension/core/TitleFilter.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.Map;
 
 import com.mitchellbosecke.pebble.extension.Filter;
+import com.mitchellbosecke.pebble.extension.escaper.RawString;
 
 public class TitleFilter implements Filter {
 
@@ -25,7 +26,7 @@ public class TitleFilter implements Filter {
         if (input == null) {
             return null;
         }
-        String value = (String) input;
+        String value = input instanceof RawString ? input.toString() : (String) input;
 
         if (value.length() == 0) {
             return value;

--- a/src/main/java/com/mitchellbosecke/pebble/extension/core/TrimFilter.java
+++ b/src/main/java/com/mitchellbosecke/pebble/extension/core/TrimFilter.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.Map;
 
 import com.mitchellbosecke.pebble.extension.Filter;
+import com.mitchellbosecke.pebble.extension.escaper.RawString;
 
 public class TrimFilter implements Filter {
 
@@ -25,7 +26,7 @@ public class TrimFilter implements Filter {
         if (input == null) {
             return null;
         }
-        String str = (String) input;
+        String str = input instanceof RawString ? input.toString() : (String) input;
         return str.trim();
     }
 

--- a/src/main/java/com/mitchellbosecke/pebble/extension/core/UpperFilter.java
+++ b/src/main/java/com/mitchellbosecke/pebble/extension/core/UpperFilter.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.Map;
 
 import com.mitchellbosecke.pebble.extension.Filter;
+import com.mitchellbosecke.pebble.extension.escaper.RawString;
 
 public class UpperFilter implements Filter {
 
@@ -25,7 +26,8 @@ public class UpperFilter implements Filter {
         if (input == null) {
             return null;
         }
-        return ((String) input).toUpperCase();
+        String str = input instanceof RawString ? input.toString() : (String) input;
+        return str.toUpperCase();
     }
 
 }

--- a/src/main/java/com/mitchellbosecke/pebble/extension/core/UrlEncoderFilter.java
+++ b/src/main/java/com/mitchellbosecke/pebble/extension/core/UrlEncoderFilter.java
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.Map;
 
 import com.mitchellbosecke.pebble.extension.Filter;
+import com.mitchellbosecke.pebble.extension.escaper.RawString;
 
 public class UrlEncoderFilter implements Filter {
 
@@ -26,7 +27,7 @@ public class UrlEncoderFilter implements Filter {
         if (input == null) {
             return null;
         }
-        String arg = (String) input;
+        String arg = input instanceof RawString ? input.toString() : (String) input;
         try {
             arg = URLEncoder.encode(arg, "UTF-8");
         } catch (UnsupportedEncodingException e) {

--- a/src/main/java/com/mitchellbosecke/pebble/extension/escaper/EscapeFilter.java
+++ b/src/main/java/com/mitchellbosecke/pebble/extension/escaper/EscapeFilter.java
@@ -92,8 +92,7 @@ public class EscapeFilter implements Filter {
             throw new RuntimeException(String.format("Unknown escaping strategy [%s]", strategy));
         }
 
-        input = strategies.get(strategy).escape(input);
-        return input;
+        return new RawString(strategies.get(strategy).escape(input));
     }
 
     public String getDefaultStrategy() {

--- a/src/main/java/com/mitchellbosecke/pebble/extension/escaper/EscaperExtension.java
+++ b/src/main/java/com/mitchellbosecke/pebble/extension/escaper/EscaperExtension.java
@@ -69,10 +69,6 @@ public class EscaperExtension extends AbstractExtension {
         visitorFactory.setAutoEscaping(auto);
     }
 
-    public void addSafeFilter(String filter) {
-        visitorFactory.addSafeFilter(filter);
-    }
-
     /**
      * Adds a custom escaping strategy to the filter.
      *

--- a/src/main/java/com/mitchellbosecke/pebble/extension/escaper/EscaperNodeVisitor.java
+++ b/src/main/java/com/mitchellbosecke/pebble/extension/escaper/EscaperNodeVisitor.java
@@ -117,9 +117,7 @@ public class EscaperNodeVisitor extends AbstractNodeVisitor {
         if (expression instanceof LiteralStringExpression) {
             safe = true;
         }
-        // function and macro calls are considered safe
-        else if (expression instanceof FunctionOrMacroInvocationExpression
-                || expression instanceof ParentFunctionExpression || expression instanceof BlockFunctionExpression) {
+        else if (expression instanceof ParentFunctionExpression || expression instanceof BlockFunctionExpression) {
             safe = true;
         } else if (expression instanceof FilterExpression) {
 

--- a/src/main/java/com/mitchellbosecke/pebble/extension/escaper/EscaperNodeVisitor.java
+++ b/src/main/java/com/mitchellbosecke/pebble/extension/escaper/EscaperNodeVisitor.java
@@ -9,11 +9,8 @@
 package com.mitchellbosecke.pebble.extension.escaper;
 
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Set;
 
 import com.mitchellbosecke.pebble.extension.AbstractNodeVisitor;
 import com.mitchellbosecke.pebble.node.ArgumentsNode;
@@ -24,7 +21,6 @@ import com.mitchellbosecke.pebble.node.expression.BlockFunctionExpression;
 import com.mitchellbosecke.pebble.node.expression.Expression;
 import com.mitchellbosecke.pebble.node.expression.FilterExpression;
 import com.mitchellbosecke.pebble.node.expression.FilterInvocationExpression;
-import com.mitchellbosecke.pebble.node.expression.FunctionOrMacroInvocationExpression;
 import com.mitchellbosecke.pebble.node.expression.LiteralStringExpression;
 import com.mitchellbosecke.pebble.node.expression.ParentFunctionExpression;
 import com.mitchellbosecke.pebble.node.expression.TernaryExpression;
@@ -36,11 +32,8 @@ public class EscaperNodeVisitor extends AbstractNodeVisitor {
 
     private final LinkedList<Boolean> active = new LinkedList<>();
 
-    private final Set<String> safeFilters;
-
-    public EscaperNodeVisitor(PebbleTemplateImpl template, List<String> safeFilters, boolean autoEscapting) {
+    public EscaperNodeVisitor(PebbleTemplateImpl template, boolean autoEscapting) {
         super(template);
-        this.safeFilters = Collections.unmodifiableSet(new LinkedHashSet<>(safeFilters));
         this.pushAutoEscapeState(autoEscapting);
     }
 
@@ -119,16 +112,6 @@ public class EscaperNodeVisitor extends AbstractNodeVisitor {
         }
         else if (expression instanceof ParentFunctionExpression || expression instanceof BlockFunctionExpression) {
             safe = true;
-        } else if (expression instanceof FilterExpression) {
-
-            // certain filters do not need to be escaped
-            FilterExpression binary = (FilterExpression) expression;
-            FilterInvocationExpression filterInvocation = (FilterInvocationExpression) binary.getRightExpression();
-            String filterName = filterInvocation.getFilterName();
-
-            if (safeFilters.contains(filterName)) {
-                safe = true;
-            }
         }
 
         return safe;

--- a/src/main/java/com/mitchellbosecke/pebble/extension/escaper/EscaperNodeVisitorFactory.java
+++ b/src/main/java/com/mitchellbosecke/pebble/extension/escaper/EscaperNodeVisitorFactory.java
@@ -1,8 +1,5 @@
 package com.mitchellbosecke.pebble.extension.escaper;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import com.mitchellbosecke.pebble.extension.NodeVisitor;
 import com.mitchellbosecke.pebble.extension.NodeVisitorFactory;
 import com.mitchellbosecke.pebble.template.PebbleTemplate;
@@ -16,22 +13,11 @@ import com.mitchellbosecke.pebble.template.PebbleTemplateImpl;
  */
 public class EscaperNodeVisitorFactory implements NodeVisitorFactory{
 
-    private final List<String> safeFilters = new ArrayList<>();
     private boolean autoEscaping = true;
-
-    public EscaperNodeVisitorFactory() {
-        safeFilters.add("raw");
-        safeFilters.add("escape");
-        safeFilters.add("date");
-    }
 
     @Override
     public NodeVisitor createVisitor(PebbleTemplate template) {
-        return new EscaperNodeVisitor((PebbleTemplateImpl)template, safeFilters, this.autoEscaping);
-    }
-
-    public void addSafeFilter(String filter) {
-        this.safeFilters.add(filter);
+        return new EscaperNodeVisitor((PebbleTemplateImpl)template, this.autoEscaping);
     }
 
     public void setAutoEscaping(boolean auto) {

--- a/src/main/java/com/mitchellbosecke/pebble/extension/escaper/RawFilter.java
+++ b/src/main/java/com/mitchellbosecke/pebble/extension/escaper/RawFilter.java
@@ -20,11 +20,9 @@ public class RawFilter implements Filter {
     }
 
     public Object apply(Object inputObject, Map<String, Object> args) {
-        /*
-         * Doesn't actually do anything to the input. This filter's existence is
-         * enough for the EscaperNodeVisitor to know not to escape this
-         * expression.
-         */
+        if(inputObject instanceof String){
+            return new RawString((String) inputObject);
+        }
         return inputObject;
     }
 

--- a/src/main/java/com/mitchellbosecke/pebble/extension/escaper/RawString.java
+++ b/src/main/java/com/mitchellbosecke/pebble/extension/escaper/RawString.java
@@ -1,0 +1,23 @@
+package com.mitchellbosecke.pebble.extension.escaper;
+
+/**
+ * Wrap a string in this to mark the string as safe to ignore by the Escape extension.
+ * 
+ * <p>
+ * <b>Warning:</b> The EscaperExtension will never escape a string that is wrapped with this class.
+ * 
+ */
+public class RawString {
+
+	private final String content;
+
+	public RawString(String content) {
+		this.content = content;
+	}
+
+	@Override
+	public String toString() {
+		return content;
+	}
+
+}

--- a/src/main/java/com/mitchellbosecke/pebble/template/PebbleTemplateImpl.java
+++ b/src/main/java/com/mitchellbosecke/pebble/template/PebbleTemplateImpl.java
@@ -10,6 +10,7 @@ package com.mitchellbosecke.pebble.template;
 
 import com.mitchellbosecke.pebble.PebbleEngine;
 import com.mitchellbosecke.pebble.error.PebbleException;
+import com.mitchellbosecke.pebble.extension.escaper.RawString;
 import com.mitchellbosecke.pebble.node.ArgumentsNode;
 import com.mitchellbosecke.pebble.node.RootNode;
 import com.mitchellbosecke.pebble.utils.FutureWriter;
@@ -276,10 +277,10 @@ public class PebbleTemplateImpl implements PebbleTemplate {
      * @return The results of the macro invocation
      * @throws PebbleException An exception that may have occurred
      */
-    public String macro(EvaluationContext context, String macroName, ArgumentsNode args, boolean ignoreOverriden)
-            throws PebbleException {
-        String result = null;
-        boolean found = false;
+    public RawString macro(EvaluationContext context, String macroName, ArgumentsNode args, boolean ignoreOverriden)
+			throws PebbleException {
+		RawString result = null;
+		boolean found = false;
 
         PebbleTemplateImpl childTemplate = context.getHierarchy().getChild();
 
@@ -296,7 +297,7 @@ public class PebbleTemplateImpl implements PebbleTemplate {
             Macro macro = macros.get(macroName);
 
             Map<String, Object> namedArguments = args.getArgumentMap(this, context, macro);
-            result = macro.call(this, context, namedArguments);
+            result = new RawString(macro.call(this, context, namedArguments));
         }
 
         // check imported templates


### PR DESCRIPTION
This PR was motivated by our use internally at our company, and realising that functions are not escaped by default. Rather than explicitly making each function escape its output before returning, we thought it would be beneficial for functions to be escaped by default, and require explicit escaping.

To achieve this, the following changes have been made.

* Introduction of test cases to check the escape behaviour of basic functions and macros.
* The introduction of `RawString.java`: a class that the `EscapeFilter` ignores (as it is not a `String`).
* Functions and Macros are not now whitelisted. Instead macros return an instance of `RawString` when evaluated, and functions return whatever they would usually. This means that macros are still never escaped, and functions are by default, but can return an instance of `RawString` to prevent escaping. `parent()` and `block()` are not affected by this.
* Filter whitelists have been removed, and a filter can return raw output (just like functions) by returning a `RawString`.
* The core filters that handle `Strings` have all been updated to handle `RawStrings` too, and continue to fail with a class cast exception in any other case.