### PR TITLE
Add PebbleEngine.Builder.build variant with custom base extensions

### DIFF
--- a/src/main/java/com/mitchellbosecke/pebble/PebbleEngine.java
+++ b/src/main/java/com/mitchellbosecke/pebble/PebbleEngine.java
@@ -455,7 +455,6 @@ public class PebbleEngine {
          */
         public PebbleEngine build() {
             List<Extension> extensions = new ArrayList<>();
-            extensions.add(new CoreExtension());
             extensions.add(escaperExtension);
             extensions.add(new I18nExtension());
             return build(extensions);
@@ -466,9 +465,12 @@ public class PebbleEngine {
          *
          * @return A PebbleEngine object that can be used to create PebbleTemplate objects.
          */
-        public PebbleEngine build(List<Extension> extensions) {
+        public PebbleEngine build(List<Extension> baseExtensions) {
 
             // core userProvidedExtensions
+            List<Extension> extensions = new ArrayList<>();
+            extensions.add(new CoreExtension());
+            extensions.addAll(baseExtensions);
             extensions.addAll(this.userProvidedExtensions);
 
             // default loader

--- a/src/main/java/com/mitchellbosecke/pebble/PebbleEngine.java
+++ b/src/main/java/com/mitchellbosecke/pebble/PebbleEngine.java
@@ -440,6 +440,15 @@ public class PebbleEngine {
         }
 
         /**
+         * Return the active escaper extension, usually for overriding the list of base extensions.
+         *
+         * @return The current escaper extension
+         */
+        public EscaperExtension getEscaperExtension() {
+            return escaperExtension;
+        }
+
+        /**
          * Creates the PebbleEngine instance, with default base extensions.
          *
          * @return A PebbleEngine object that can be used to create PebbleTemplate objects.

--- a/src/main/java/com/mitchellbosecke/pebble/PebbleEngine.java
+++ b/src/main/java/com/mitchellbosecke/pebble/PebbleEngine.java
@@ -440,17 +440,26 @@ public class PebbleEngine {
         }
 
         /**
-         * Creates the PebbleEngine instance.
+         * Creates the PebbleEngine instance, with default base extensions.
          *
          * @return A PebbleEngine object that can be used to create PebbleTemplate objects.
          */
         public PebbleEngine build() {
-
-            // core userProvidedExtensions
             List<Extension> extensions = new ArrayList<>();
             extensions.add(new CoreExtension());
             extensions.add(escaperExtension);
             extensions.add(new I18nExtension());
+            return build(extensions);
+        }
+
+        /**
+         * Creates the PebbleEngine instance with a custom list of base extensions.
+         *
+         * @return A PebbleEngine object that can be used to create PebbleTemplate objects.
+         */
+        public PebbleEngine build(List<Extension> extensions) {
+
+            // core userProvidedExtensions
             extensions.addAll(this.userProvidedExtensions);
 
             // default loader


### PR DESCRIPTION
This fixes issue mbosecke/pebble#151, where default base extensions (i.e. `i18n`) can be substituted for user-provided ones, in case there are issues with the default set.

A new variant of `PebbleEngine.Builder.build` simply accepts a `List` of `Extensions`, which will be used along with any `userProvidedExtensions` otherwise given to `Builder`.

The existing API is unchanged, and returns the result of the new method, but with the existing list of default extensions.